### PR TITLE
Handle when a build file doesn't have a file reference gracefully

### DIFF
--- a/Sources/pbxbuild/Target/Environment.cpp
+++ b/Sources/pbxbuild/Target/Environment.cpp
@@ -31,6 +31,10 @@ BuildFileDisambiguation(pbxproj::PBX::Target::shared_ptr const &target)
         }
 
         for (pbxproj::PBX::BuildFile::shared_ptr const &buildFile : buildPhase->files()) {
+            if (buildFile->fileRef() == NULL) {
+                continue;
+            }
+
             std::string name = FSUtil::GetBaseNameWithoutExtension(buildFile->fileRef()->name());
 
             /* Use a case-insensitive key to detect conflicts. */

--- a/Sources/pbxbuild/Tool/HeadermapResolver.cpp
+++ b/Sources/pbxbuild/Tool/HeadermapResolver.cpp
@@ -40,6 +40,10 @@ HeadermapSearchPaths(pbxspec::Manager::shared_ptr const &specManager, pbxsetting
         }
 
         for (pbxproj::PBX::BuildFile::shared_ptr const &buildFile : buildPhase->files()) {
+            if (buildFile->fileRef() == NULL) {
+                continue;
+            }
+
             std::string filePath = environment.expand(buildFile->fileRef()->resolve());
             std::string fullPath = FSUtil::GetDirectoryName(filePath);
             if (allHeaderSearchPaths.insert(fullPath).second) {


### PR DESCRIPTION
Glad that the Workflow `pbxproj` is super nice and clean.
