### PR TITLE
Eliminate copies in for loops by using const references

### DIFF
--- a/Sources/pbxbuild/Phase/ProductTypeResolver.cpp
+++ b/Sources/pbxbuild/Phase/ProductTypeResolver.cpp
@@ -238,7 +238,7 @@ ResolveFrameworkStructure(Phase::Environment const &phaseEnvironment, Phase::Con
         /*
          * The symlinks to create are now determined. Add the symlinks.
          */
-        for (Symlink symlink : symlinks) {
+        for (Symlink const &symlink : symlinks) {
             pbxsetting::Value const &value = symlinkDirectories.at(symlink);
             std::string valueDirectory = targetBuildDirectory + "/" + environment.expand(value);
 

--- a/Sources/pbxbuild/Phase/SwiftResolver.cpp
+++ b/Sources/pbxbuild/Phase/SwiftResolver.cpp
@@ -104,7 +104,7 @@ CollectScanDirectories(
         }
 
         std::vector<Phase::File> files = Phase::File::ResolveBuildFiles(phaseEnvironment, environment, buildPhase->files());
-        for (Phase::File const file : files) {
+        for (Phase::File const &file : files) {
             if (file.fileType() != nullptr && file.fileType()->isFrameworkWrapper()) {
                 directories.push_back(file.path());
             }

--- a/Sources/pbxproj/PBX/Project.cpp
+++ b/Sources/pbxproj/PBX/Project.cpp
@@ -298,7 +298,7 @@ Open(std::string const &path)
     //
     // Transfer all file references from cache.
     //
-    for (auto I : context.fileReferences) {
+    for (auto const &I : context.fileReferences) {
         project->_fileReferences.push_back(I.second);
     }
 

--- a/Sources/pbxsetting/Environment.cpp
+++ b/Sources/pbxsetting/Environment.cpp
@@ -122,7 +122,7 @@ std::string Environment::
 resolveValue(Condition const &condition, Value const &value, InheritanceContext const &context) const
 {
     std::string result;
-    for (auto entry : value.entries()) {
+    for (auto const &entry : value.entries()) {
         switch (entry.type) {
             case Value::Entry::String: {
                 result += entry.string;

--- a/Sources/plist/Dictionary.cpp
+++ b/Sources/plist/Dictionary.cpp
@@ -34,7 +34,7 @@ merge(Dictionary const *dict, bool replace)
     if (dict == nullptr || dict == this)
         return;
 
-    for (auto key : *dict) {
+    for (auto const &key : *dict) {
         if (replace || _map.find(key) == _map.end()) {
             set(key, dict->value(key)->copy());
         }

--- a/Sources/plist/Format/SimpleXMLParser.cpp
+++ b/Sources/plist/Format/SimpleXMLParser.cpp
@@ -55,7 +55,7 @@ onStartElement(std::string const &name, std::unordered_map<std::string, std::str
 {
     Dictionary *dict = Dictionary::New().release();
 
-    for (auto I : attrs) {
+    for (auto const &I : attrs) {
         if (I.second == "YES") {
             dict->set(I.first, Boolean::New(true));
         } else if (I.second == "NO") {

--- a/Sources/plist/Format/XMLParser.cpp
+++ b/Sources/plist/Format/XMLParser.cpp
@@ -48,7 +48,7 @@ onEndParse(bool success)
         if (_state.current != nullptr && _state.current != _root) {
             _state.current->release();
         }
-        for (auto s : _stack) {
+        for (auto const &s : _stack) {
             if (s.current != _state.current && s.current != _root) {
                 s.current->release();
             }

--- a/Sources/xcdriver/ListAction.cpp
+++ b/Sources/xcdriver/ListAction.cpp
@@ -63,7 +63,7 @@ Run(Options const &options)
             printf("\n%4sThis workspace contains no scheme.\n", "");
         } else {
             printf("%4sSchemes:\n", "");
-            for (auto scheme : schemes) {
+            for (auto const &scheme : schemes) {
                 printf("%8s%s\n", "", scheme->name().c_str());
             }
             printf("\n");
@@ -75,7 +75,7 @@ Run(Options const &options)
 
         if (!project->targets().empty()) {
             printf("%4sTargets:\n", "");
-            for (auto target : project->targets()) {
+            for (auto const &target : project->targets()) {
                 printf("%8s%s\n", "", target->name().c_str());
             }
         } else {
@@ -85,7 +85,7 @@ Run(Options const &options)
 
         if (project->buildConfigurationList()) {
             printf("%4sBuild Configurations:\n", "");
-            for (auto config : *project->buildConfigurationList()) {
+            for (auto const &config : *project->buildConfigurationList()) {
                 printf("%8s%s\n", "", config->name().c_str());
             }
             printf("\n%4sIf no build configuration is specified and -scheme is not passed then \"%s\" is used.\n", "", project->buildConfigurationList()->defaultConfigurationName().c_str());
@@ -98,7 +98,7 @@ Run(Options const &options)
             printf("\n%4sThis project contains no scheme.\n", "");
         } else {
             printf("%4sSchemes:\n", "");
-            for (auto scheme : schemes) {
+            for (auto const &scheme : schemes) {
                 printf("%8s%s\n", "", scheme->name().c_str());
             }
             printf("\n");

--- a/Sources/xcdriver/ShowSDKsAction.cpp
+++ b/Sources/xcdriver/ShowSDKsAction.cpp
@@ -35,9 +35,9 @@ Run(Options const &options)
         return 1;
     }
 
-    for (auto platform : manager->platforms()) {
+    for (auto const &platform : manager->platforms()) {
         printf("%s SDKs:\n", platform->description().c_str());
-        for (auto target : platform->targets()) {
+        for (auto const &target : platform->targets()) {
             printf("\t%-32s-sdk %s\n", target->displayName().c_str(), target->canonicalName().c_str());
         }
         printf("\n");


### PR DESCRIPTION
Replace instances of `for (T var : items)` with `for (T const &var : items)` for performance and idiom sake.

There is almost no nuance in this diff, I looked for loops that didn't have `&` and updated them, without investigating whether any of these had a specific but uncommented reason for being copied.
