### PR TITLE
Build with GCC 4.8/4.9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 # Enable all warnings.
 add_compile_options(-Wall -Werror)
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-  add_compile_options(-Wno-multichar -Wno-sign-compare)
+  add_compile_options(-Wno-multichar -Wno-sign-compare -fno-strict-aliasing)
 endif ()
 
 # Enable color diagnostics.

--- a/Libraries/builtin/Sources/copyPlist/Driver.cpp
+++ b/Libraries/builtin/Sources/copyPlist/Driver.cpp
@@ -88,7 +88,7 @@ run(std::vector<std::string> const &args, std::unordered_map<std::string, std::s
      */
     for (std::string const &inputPath : options.inputs()) {
         /* Read in the input. */
-        std::ifstream inputFile = std::ifstream(FSUtil::ResolveRelativePath(inputPath, workingDirectory), std::ios::binary);
+        std::ifstream inputFile(FSUtil::ResolveRelativePath(inputPath, workingDirectory), std::ios::binary);
         if (inputFile.fail()) {
             fprintf(stderr, "error: unable to read input %s\n", inputPath.c_str());
             return 1;
@@ -134,7 +134,7 @@ run(std::vector<std::string> const &args, std::unordered_map<std::string, std::s
         std::string outputPath = FSUtil::ResolveRelativePath(options.outputDirectory(), workingDirectory) + "/" + FSUtil::GetBaseName(inputPath);
 
         /* Write out the output. */
-        std::ofstream outputFile = std::ofstream(outputPath, std::ios::binary);
+        std::ofstream outputFile(outputPath, std::ios::binary);
         if (outputFile.fail()) {
             fprintf(stderr, "error: could not open output path %s to write\n", outputPath.c_str());
             return 1;

--- a/Libraries/builtin/Sources/copyStrings/Driver.cpp
+++ b/Libraries/builtin/Sources/copyStrings/Driver.cpp
@@ -134,7 +134,7 @@ run(std::vector<std::string> const &args, std::unordered_map<std::string, std::s
     for (std::string const &inputPath : options.inputs()) {
         /* Read in the input. */
         std::string resolvedInputPath = FSUtil::ResolveRelativePath(inputPath, workingDirectory);
-        std::ifstream inputFile = std::ifstream(resolvedInputPath, std::ios::binary);
+        std::ifstream inputFile(resolvedInputPath, std::ios::binary);
         if (inputFile.fail()) {
             fprintf(stderr, "error: unable to read input %s\n", inputPath.c_str());
             return 1;

--- a/Libraries/builtin/Sources/infoPlistUtility/Driver.cpp
+++ b/Libraries/builtin/Sources/infoPlistUtility/Driver.cpp
@@ -52,7 +52,7 @@ WritePkgInfo(plist::Dictionary const *root, std::string const &path)
         pkgInfo += "????";
     }
 
-    std::ofstream pkgInfoFile = std::ofstream(path, std::ios::binary);
+    std::ofstream pkgInfoFile(path, std::ios::binary);
     if (pkgInfoFile.fail()) {
         return std::make_pair(false, "could not open output path " + path + " to write");
     }
@@ -149,7 +149,7 @@ run(std::vector<std::string> const &args, std::unordered_map<std::string, std::s
     pbxsetting::Environment settingsEnvironment = CreateBuildEnvironment(environment);
 
     /* Read in the input. */
-    std::ifstream inputFile = std::ifstream(FSUtil::ResolveRelativePath(options.input(), workingDirectory), std::ios::binary);
+    std::ifstream inputFile(FSUtil::ResolveRelativePath(options.input(), workingDirectory), std::ios::binary);
     if (inputFile.fail()) {
         fprintf(stderr, "error: unable to read input %s\n", options.input().c_str());
         return 1;
@@ -242,13 +242,13 @@ run(std::vector<std::string> const &args, std::unordered_map<std::string, std::s
     if (!options.resourceRulesFile().empty()) {
         std::string resourceRulesInputPath = settingsEnvironment.resolve("CODE_SIGN_RESOURCE_RULES_PATH");
         if (!resourceRulesInputPath.empty()) {
-            std::ifstream resourceRulesInput = std::ifstream(FSUtil::ResolveRelativePath(resourceRulesInputPath, workingDirectory), std::ios::binary);
+            std::ifstream resourceRulesInput(FSUtil::ResolveRelativePath(resourceRulesInputPath, workingDirectory), std::ios::binary);
             if (resourceRulesInput.fail()) {
                 fprintf(stderr, "error: unable to read input %s\n", resourceRulesInputPath.c_str());
                 return 1;
             }
 
-            std::ofstream resourceRulesOutput = std::ofstream(FSUtil::ResolveRelativePath(options.resourceRulesFile(), workingDirectory), std::ios::binary);
+            std::ofstream resourceRulesOutput(FSUtil::ResolveRelativePath(options.resourceRulesFile(), workingDirectory), std::ios::binary);
             if (resourceRulesOutput.fail()) {
                 fprintf(stderr, "error: could not open output path %s to write\n", options.resourceRulesFile().c_str());
                 return 1;
@@ -288,7 +288,7 @@ run(std::vector<std::string> const &args, std::unordered_map<std::string, std::s
     }
 
     /* Write out the output. */
-    std::ofstream outputFile = std::ofstream(FSUtil::ResolveRelativePath(options.output(), workingDirectory), std::ios::binary);
+    std::ofstream outputFile(FSUtil::ResolveRelativePath(options.output(), workingDirectory), std::ios::binary);
     if (outputFile.fail()) {
         fprintf(stderr, "error: could not open output path %s to write\n", options.output().c_str());
         return 1;

--- a/Libraries/dependency/Tools/dependency-info-tool.cpp
+++ b/Libraries/dependency/Tools/dependency-info-tool.cpp
@@ -144,7 +144,7 @@ static bool
 LoadDependencyInfo(std::string const &path, dependency::DependencyInfoFormat format, std::vector<dependency::DependencyInfo> *dependencyInfo)
 {
     if (format == dependency::DependencyInfoFormat::Binary) {
-        std::ifstream input = std::ifstream(path, std::ios::binary);
+        std::ifstream input(path, std::ios::binary);
         if (input.fail()) {
             fprintf(stderr, "error: failed to open %s\n", path.c_str());
             return false;
@@ -170,7 +170,7 @@ LoadDependencyInfo(std::string const &path, dependency::DependencyInfoFormat for
         dependencyInfo->push_back(directoryInfo->dependencyInfo());
         return true;
     } else if (format == dependency::DependencyInfoFormat::Makefile) {
-        std::ifstream input = std::ifstream(path, std::ios::binary);
+        std::ifstream input(path, std::ios::binary);
         if (input.fail()) {
             fprintf(stderr, "error: failed to open %s\n", path.c_str());
             return false;
@@ -264,7 +264,7 @@ main(int argc, char **argv)
     /*
      * Write out the output.
      */
-    std::ofstream output = std::ofstream(options.output(), std::ios::binary);
+    std::ofstream output(options.output(), std::ios::binary);
     if (output.fail()) {
         return false;
     }

--- a/Libraries/libutil/Headers/libutil/Subprocess.h
+++ b/Libraries/libutil/Headers/libutil/Subprocess.h
@@ -33,7 +33,9 @@ public:
                  std::ostream *output = nullptr,
                  std::ostream *error = nullptr)
     {
-        return execute(path, { }, { }, "", input, output, error);
+        std::vector<std::string> emptyVector;
+        std::unordered_map<std::string, std::string> emptyMap;
+        return execute(path, emptyVector, emptyMap, "", input, output, error);
     }
 
     bool execute(std::string const &path,
@@ -42,7 +44,8 @@ public:
                  std::ostream *output = nullptr,
                  std::ostream *error = nullptr)
     {
-        return execute(path, arguments, { }, "", input, output, error);
+        std::unordered_map<std::string, std::string> emptyMap;
+        return execute(path, arguments, emptyMap, "", input, output, error);
     }
 
     bool execute(std::string const &path,

--- a/Libraries/pbxbuild/Headers/pbxbuild/Tool/OptionsResult.h
+++ b/Libraries/pbxbuild/Headers/pbxbuild/Tool/OptionsResult.h
@@ -41,7 +41,7 @@ public:
         std::string const &workingDirectory,
         std::vector<pbxspec::PBX::PropertyOption::shared_ptr> const &options,
         pbxspec::PBX::FileType::shared_ptr const &fileType,
-        std::unordered_set<std::string> const &deletedSettings = { });
+        std::unordered_set<std::string> const &deletedSettings = std::unordered_set<std::string>());
 
     static OptionsResult Create(
         Tool::Environment const &toolEnvironment,

--- a/Libraries/pbxbuild/Sources/FileTypeResolver.cpp
+++ b/Libraries/pbxbuild/Sources/FileTypeResolver.cpp
@@ -28,7 +28,8 @@ SortedFileTypes(std::vector<pbxspec::PBX::FileType::shared_ptr> const &fileTypes
         if (fileType->base() != nullptr) {
             graph.insert(fileType->base(), { fileType });
         }
-        graph.insert(fileType, { });
+        const std::unordered_set<pbxspec::PBX::FileType::shared_ptr> emptySet;
+        graph.insert(fileType, emptySet);
     }
 
     return graph.ordered();

--- a/Libraries/pbxbuild/Sources/Tool/Tokens.cpp
+++ b/Libraries/pbxbuild/Sources/Tool/Tokens.cpp
@@ -28,7 +28,7 @@ Expand(
      * Split the tokens on spaces.
      */
     std::vector<std::string> tokens;
-    std::stringstream sstream = std::stringstream(tokenized);
+    std::stringstream sstream(tokenized);
     std::copy(std::istream_iterator<std::string>(sstream), std::istream_iterator<std::string>(), std::back_inserter(tokens));
 
     /*

--- a/Libraries/pbxbuild/Tools/dump_hmap.cpp
+++ b/Libraries/pbxbuild/Tools/dump_hmap.cpp
@@ -22,7 +22,7 @@ main(int argc, char **argv)
         return -1;
     }
 
-    std::ifstream file = std::ifstream(argv[1], std::ios::binary);
+    std::ifstream file(argv[1], std::ios::binary);
     std::vector<uint8_t> contents = std::vector<uint8_t>(std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>());
 
     HeaderMap hmap;

--- a/Libraries/pbxsetting/Sources/Condition.cpp
+++ b/Libraries/pbxsetting/Sources/Condition.cpp
@@ -45,6 +45,7 @@ match(Condition const &condition) const
 Condition const &Condition::
 Empty(void)
 {
-    static Condition *condition = new Condition({ });
+    std::unordered_map<std::string, std::string> emptyMap;
+    static Condition *condition = new Condition(emptyMap);
     return *condition;
 }

--- a/Libraries/pbxsetting/Sources/Value.cpp
+++ b/Libraries/pbxsetting/Sources/Value.cpp
@@ -133,7 +133,7 @@ ParseValue(std::string const &value, size_t from, ValueDelimiter end = kDelimite
     size_t append_offset = from;
 
     do {
-        size_t to;
+        size_t to = 0;
         switch (end) {
             case kDelimiterNone: {
                 to = value.size();

--- a/Libraries/pbxspec/Headers/pbxspec/PBX/BuildRule.h
+++ b/Libraries/pbxspec/Headers/pbxspec/PBX/BuildRule.h
@@ -42,7 +42,6 @@ public:
     { return _compilerSpec; }
 
 protected:
-    friend class pbxspec::Manager;
     bool parse(plist::Dictionary const *dict);
 };
 

--- a/Libraries/plist/Headers/plist/Format/Format.h
+++ b/Libraries/plist/Headers/plist/Format/Format.h
@@ -42,7 +42,7 @@ public:
     static std::pair<std::unique_ptr<Object>, std::string>
     Read(std::string const &path)
     {
-        std::ifstream file = std::ifstream(path, std::ios::binary);
+        std::ifstream file(path, std::ios::binary);
         std::vector<uint8_t> contents = std::vector<uint8_t>(std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>());
 
         std::unique_ptr<T> format = Identify(contents);
@@ -62,7 +62,7 @@ public:
             return std::make_pair(false, result.second);
         }
 
-        std::ofstream file = std::ofstream(path, std::ios::binary);
+        std::ofstream file(path, std::ios::binary);
         std::copy(result.first->begin(), result.first->end(), std::ostream_iterator<char>(file));
 
         return std::make_pair(true, std::string());

--- a/Libraries/plist/Sources/Format/ABPWriter.cpp
+++ b/Libraries/plist/Sources/Format/ABPWriter.cpp
@@ -416,7 +416,7 @@ _ABPWriterProcessObject(ABPContext *context, Object const **object, uint32_t *re
     if (it != context->references.end()) {
         *refno = it->second;
 
-        /* 
+        /*
          * Yes, invalidate newObject so the caller knows that this is
          * a reference.
          */

--- a/Libraries/plist/Tools/plutil.cpp
+++ b/Libraries/plist/Tools/plutil.cpp
@@ -411,7 +411,7 @@ Read(std::string const &path = "-")
         contents = std::vector<uint8_t>(std::istreambuf_iterator<char>(std::cin), std::istreambuf_iterator<char>());
     } else {
         /* Read from file. */
-        std::ifstream file = std::ifstream(path, std::ios::binary);
+        std::ifstream file(path, std::ios::binary);
         if (file.fail()) {
             return std::make_pair(false, std::vector<uint8_t>());
         }
@@ -430,7 +430,7 @@ Write(std::vector<uint8_t> const &contents, std::string const &path = "-")
         std::copy(contents.begin(), contents.end(), std::ostream_iterator<char>(std::cout));
     } else {
         /* Read from file. */
-        std::ofstream file = std::ofstream(path, std::ios::binary);
+        std::ofstream file(path, std::ios::binary);
         if (file.fail()) {
             return false;
         }

--- a/Libraries/xcexecution/Sources/NinjaExecutor.cpp
+++ b/Libraries/xcexecution/Sources/NinjaExecutor.cpp
@@ -244,7 +244,7 @@ ShouldGenerateNinja(bool generate, Parameters const &buildParameters, std::strin
      * If the contents of the configration hash doesn't match, need to update for
      * the new configuration.
      */
-    std::ifstream file = std::ifstream(configurationHashPath, std::ios::binary);
+    std::ifstream file(configurationHashPath, std::ios::binary);
     if (file.fail()) {
         /* Can't be read, same as not existing. */
         return true;

--- a/Libraries/xcexecution/Sources/SimpleExecutor.cpp
+++ b/Libraries/xcexecution/Sources/SimpleExecutor.cpp
@@ -106,7 +106,8 @@ SortInvocations(std::vector<pbxbuild::Tool::Invocation> const &invocations)
 
     pbxbuild::DirectedGraph<pbxbuild::Tool::Invocation const *> graph;
     for (pbxbuild::Tool::Invocation const &invocation : invocations) {
-        graph.insert(&invocation, { });
+        std::unordered_set<pbxbuild::Tool::Invocation const *> emptySet;
+        graph.insert(&invocation, emptySet);
 
         for (std::string const &input : invocation.inputs()) {
             auto it = outputToInvocation.find(input);

--- a/Libraries/xcsdk/CMakeLists.txt
+++ b/Libraries/xcsdk/CMakeLists.txt
@@ -22,4 +22,3 @@ target_include_directories(xcsdk PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/Headers")
 
 add_executable(xcrun Tools/xcrun.cpp)
 target_link_libraries(xcrun xcsdk util)
-


### PR DESCRIPTION
I'm working on building xcbuild on some centOS machines with GCC 4.8/4.9 installed.  Upgrading GCC to 5.0 isn't an option since I don't control the packaging available, so I opted to make xcbuild happily build instead.