### PR TITLE
Support `make install` with `PREFIX=` to install xcbuild.

### DIFF
--- a/Libraries/acdriver/CMakeLists.txt
+++ b/Libraries/acdriver/CMakeLists.txt
@@ -12,9 +12,11 @@ add_library(acdriver SHARED
 
 target_link_libraries(acdriver PUBLIC xcassets util plist ext)
 target_include_directories(acdriver PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/Headers")
+install(TARGETS acdriver DESTINATION lib)
 
 add_executable(actool Tools/actool.cpp)
 target_link_libraries(actool PRIVATE acdriver)
+install(TARGETS actool DESTINATION bin)
 
 ADD_UNIT_GTEST(acdriver Options Tests/test_Options.cpp)
 ADD_UNIT_GTEST(acdriver Output Tests/test_Output.cpp)

--- a/Libraries/builtin/CMakeLists.txt
+++ b/Libraries/builtin/CMakeLists.txt
@@ -51,32 +51,42 @@ endif ()
 
 target_link_libraries(builtin PUBLIC util plist pbxsetting ${CORE_FOUNDATION} ${CORE_SERVICES})
 target_include_directories(builtin PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/Headers")
+install(TARGETS builtin DESTINATION lib)
 
 add_executable(builtin-copy Tools/copy.cpp)
 target_link_libraries(builtin-copy builtin)
+install(TARGETS builtin-copy DESTINATION bin)
 
 add_executable(builtin-copyPlist Tools/copyPlist.cpp)
 target_link_libraries(builtin-copyPlist builtin)
+install(TARGETS builtin-copyPlist DESTINATION bin)
 
 add_executable(builtin-copyStrings Tools/copyStrings.cpp)
 target_link_libraries(builtin-copyStrings builtin)
+install(TARGETS builtin-copyStrings DESTINATION bin)
 
 add_executable(builtin-copyTiff Tools/copyTiff.cpp)
 target_link_libraries(builtin-copyTiff builtin)
+install(TARGETS builtin-copyTiff DESTINATION bin)
 
 add_executable(builtin-infoPlistUtility Tools/infoPlistUtility.cpp)
 target_link_libraries(builtin-infoPlistUtility builtin)
+install(TARGETS builtin-infoPlistUtility DESTINATION bin)
 
 add_executable(builtin-lsRegisterURL Tools/lsRegisterURL.cpp)
 target_link_libraries(builtin-lsRegisterURL builtin)
+install(TARGETS builtin-lsRegisterURL DESTINATION bin)
 
 add_executable(builtin-productPackagingUtility Tools/productPackagingUtility.cpp)
 target_link_libraries(builtin-productPackagingUtility builtin)
+install(TARGETS builtin-productPackagingUtility DESTINATION bin)
 
 add_executable(builtin-validationUtility Tools/validationUtility.cpp)
 target_link_libraries(builtin-validationUtility builtin)
+install(TARGETS builtin-validationUtility DESTINATION bin)
 
 add_executable(builtin-embeddedBinaryValidationUtility Tools/embeddedBinaryValidationUtility.cpp)
 target_link_libraries(builtin-embeddedBinaryValidationUtility builtin)
+install(TARGETS builtin-embeddedBinaryValidationUtility DESTINATION bin)
 
 ADD_UNIT_GTEST(builtin copyStrings Tests/test_copyStrings.cpp)

--- a/Libraries/dependency/CMakeLists.txt
+++ b/Libraries/dependency/CMakeLists.txt
@@ -17,9 +17,11 @@ add_library(dependency SHARED
 
 target_link_libraries(dependency PUBLIC util ext)
 target_include_directories(dependency PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/Headers")
+install(TARGETS dependency DESTINATION lib)
 
 add_executable(dependency-info-tool Tools/dependency-info-tool.cpp)
 target_link_libraries(dependency-info-tool dependency util)
+install(TARGETS dependency-info-tool DESTINATION bin)
 
 ADD_UNIT_GTEST(dependency BinaryDependencyInfo Tests/test_BinaryDependencyInfo.cpp)
 ADD_UNIT_GTEST(dependency MakefileDependencyInfo Tests/test_MakefileDependencyInfo.cpp)

--- a/Libraries/ext/CMakeLists.txt
+++ b/Libraries/ext/CMakeLists.txt
@@ -13,4 +13,5 @@ add_library(ext SHARED
 
 target_link_libraries(ext PUBLIC)
 target_include_directories(ext PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/Headers")
+install(TARGETS ext DESTINATION lib)
 

--- a/Libraries/libbom/CMakeLists.txt
+++ b/Libraries/libbom/CMakeLists.txt
@@ -8,9 +8,11 @@ add_library(bom SHARED
 
 target_link_libraries(bom PUBLIC)
 target_include_directories(bom PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/Headers")
+install(TARGETS bom DESTINATION lib)
 
 add_executable(lsbom Tools/lsbom.cpp)
 target_link_libraries(lsbom PRIVATE util bom)
+install(TARGETS lsbom DESTINATION bin)
 
 add_executable(dump_bom Tools/dump_bom.c)
 target_link_libraries(dump_bom PRIVATE bom)

--- a/Libraries/libcar/CMakeLists.txt
+++ b/Libraries/libcar/CMakeLists.txt
@@ -19,6 +19,7 @@ endif ()
 
 target_link_libraries(car PUBLIC ext bom ${COMPRESSION})
 target_include_directories(car PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/Headers")
+install(TARGETS car DESTINATION lib)
 
 add_executable(dump_car Tools/dump_car.cpp)
 target_link_libraries(dump_car PRIVATE car)

--- a/Libraries/libutil/CMakeLists.txt
+++ b/Libraries/libutil/CMakeLists.txt
@@ -25,6 +25,7 @@ add_library(util SHARED
 
 target_link_libraries(util PUBLIC ext)
 target_include_directories(util PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/Headers")
+install(TARGETS util DESTINATION lib)
 
 ADD_UNIT_GTEST(util MemoryFilesystem Tests/test_MemoryFilesystem.cpp)
 ADD_UNIT_GTEST(util FSUtil Tests/test_FSUtil.cpp)

--- a/Libraries/ninja/CMakeLists.txt
+++ b/Libraries/ninja/CMakeLists.txt
@@ -14,6 +14,7 @@ add_library(ninja SHARED
 
 target_link_libraries(ninja PUBLIC)
 target_include_directories(ninja PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/Headers")
+install(TARGETS ninja DESTINATION lib)
 
 ADD_UNIT_GTEST(ninja Value Tests/test_Value.cpp)
 ADD_UNIT_GTEST(ninja Writer Tests/test_Writer.cpp)

--- a/Libraries/pbxbuild/CMakeLists.txt
+++ b/Libraries/pbxbuild/CMakeLists.txt
@@ -63,6 +63,7 @@ add_library(pbxbuild SHARED
 
 target_link_libraries(pbxbuild PUBLIC xcsdk xcworkspace xcscheme pbxproj pbxspec pbxsetting dependency util plist ext)
 target_include_directories(pbxbuild PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/Headers")
+install(TARGETS pbxbuild DESTINATION lib)
 
 add_executable(dump_hmap Tools/dump_hmap.cpp)
 target_link_libraries(dump_hmap pbxbuild util plist)

--- a/Libraries/pbxproj/CMakeLists.txt
+++ b/Libraries/pbxproj/CMakeLists.txt
@@ -43,6 +43,7 @@ add_library(pbxproj SHARED
 target_link_libraries(pbxproj PUBLIC pbxsetting util plist)
 target_include_directories(pbxproj PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/Headers")
 target_include_directories(pbxproj PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/PrivateHeaders")
+install(TARGETS pbxproj DESTINATION lib)
 
 add_executable(dump_xcodeproj Tools/dump_xcodeproj.cpp)
 target_link_libraries(dump_xcodeproj pbxproj xcscheme pbxsetting util plist)

--- a/Libraries/pbxsetting/CMakeLists.txt
+++ b/Libraries/pbxsetting/CMakeLists.txt
@@ -23,6 +23,7 @@ add_library(pbxsetting SHARED
 target_link_libraries(pbxsetting PUBLIC util plist)
 target_include_directories(pbxsetting PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/Headers")
 target_include_directories(pbxsetting PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/PrivateHeaders")
+install(TARGETS pbxsetting DESTINATION lib)
 
 add_executable(dump_xcconfig Tools/dump_xcconfig.cpp)
 target_link_libraries(dump_xcconfig pbxsetting util)

--- a/Libraries/pbxspec/CMakeLists.txt
+++ b/Libraries/pbxspec/CMakeLists.txt
@@ -31,6 +31,7 @@ add_library(pbxspec SHARED
 target_link_libraries(pbxspec PUBLIC pbxsetting util plist ext)
 target_include_directories(pbxspec PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/Headers")
 target_include_directories(pbxspec PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/PrivateHeaders")
+install(TARGETS pbxspec DESTINATION lib)
 
 add_executable(dump_xcspec Tools/dump_xcspec.cpp)
 target_link_libraries(dump_xcspec pbxspec)

--- a/Libraries/plist/CMakeLists.txt
+++ b/Libraries/plist/CMakeLists.txt
@@ -58,12 +58,14 @@ add_library(plist SHARED
 find_package(LibXml2 REQUIRED)
 target_include_directories(plist PRIVATE "${LIBXML2_INCLUDE_DIR}")
 target_link_libraries(plist PUBLIC xml2)
+install(TARGETS plist DESTINATION lib)
 
 target_include_directories(plist PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/Headers")
 target_include_directories(plist PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/PrivateHeaders")
 
 add_executable(plutil Tools/plutil.cpp)
 target_link_libraries(plutil plist util)
+install(TARGETS plutil DESTINATION bin)
 
 ADD_UNIT_GTEST(plist Boolean Tests/test_Boolean.cpp)
 ADD_UNIT_GTEST(plist String Tests/test_String.cpp)

--- a/Libraries/xcassets/CMakeLists.txt
+++ b/Libraries/xcassets/CMakeLists.txt
@@ -36,6 +36,7 @@ add_library(xcassets SHARED
 
 target_link_libraries(xcassets PUBLIC util plist ext)
 target_include_directories(xcassets PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/Headers")
+install(TARGETS xcassets DESTINATION lib)
 
 add_executable(dump_xcassets Tools/dump_xcassets.cpp)
 target_link_libraries(dump_xcassets PRIVATE xcassets)

--- a/Libraries/xcdriver/CMakeLists.txt
+++ b/Libraries/xcdriver/CMakeLists.txt
@@ -21,13 +21,16 @@ add_library(xcdriver SHARED
 
 target_link_libraries(xcdriver PUBLIC xcexecution xcformatter pbxbuild xcworkspace xcsdk pbxsetting util plist builtin)
 target_include_directories(xcdriver PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/Headers")
+install(TARGETS xcdriver DESTINATION lib)
 
 add_executable(xcbuild Tools/xcbuild.cpp)
 target_link_libraries(xcbuild xcdriver)
+install(TARGETS xcbuild DESTINATION bin)
 
 add_custom_command(TARGET xcbuild
                    COMMAND ${CMAKE_COMMAND} -E create_symlink $<TARGET_FILE_NAME:xcbuild> $<TARGET_FILE_DIR:xcbuild>/xcodebuild
                    DEPENDS $<TARGET_FILE:xcbuild>)
+install(FILES $<TARGET_FILE_DIR:xcbuild>/xcodebuild DESTINATION bin)
 
 ADD_UNIT_GTEST(xcdriver Options Tests/test_Options.cpp)
 ADD_UNIT_GTEST(xcdriver Action Tests/test_Action.cpp)

--- a/Libraries/xcexecution/CMakeLists.txt
+++ b/Libraries/xcexecution/CMakeLists.txt
@@ -17,3 +17,4 @@ add_library(xcexecution SHARED
 
 target_link_libraries(xcexecution PUBLIC xcformatter pbxbuild xcscheme xcworkspace pbxproj pbxsetting util dependency ninja builtin)
 target_include_directories(xcexecution PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/Headers")
+install(TARGETS xcexecution DESTINATION lib)

--- a/Libraries/xcformatter/CMakeLists.txt
+++ b/Libraries/xcformatter/CMakeLists.txt
@@ -14,3 +14,4 @@ add_library(xcformatter SHARED
 
 target_link_libraries(xcformatter PUBLIC pbxbuild pbxproj pbxsetting)
 target_include_directories(xcformatter PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/Headers")
+install(TARGETS xcformatter DESTINATION lib)

--- a/Libraries/xcscheme/CMakeLists.txt
+++ b/Libraries/xcscheme/CMakeLists.txt
@@ -30,3 +30,4 @@ add_library(xcscheme SHARED
 
 target_link_libraries(xcscheme PUBLIC pbxsetting util plist)
 target_include_directories(xcscheme PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/Headers")
+install(TARGETS xcscheme DESTINATION lib)

--- a/Libraries/xcsdk/CMakeLists.txt
+++ b/Libraries/xcsdk/CMakeLists.txt
@@ -19,8 +19,10 @@ add_library(xcsdk SHARED
 
 target_link_libraries(xcsdk PUBLIC pbxsetting util plist)
 target_include_directories(xcsdk PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/Headers")
+install(TARGETS xcsdk DESTINATION lib)
 
 add_executable(xcrun Tools/xcrun.cpp)
 target_link_libraries(xcrun xcsdk util)
+install(TARGETS xcrun DESTINATION bin)
 
 ADD_UNIT_GTEST(xcsdk PlatformVersion Tests/test_PlatformVersion.cpp)

--- a/Libraries/xcworkspace/CMakeLists.txt
+++ b/Libraries/xcworkspace/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(xcworkspace SHARED
 
 target_link_libraries(xcworkspace PUBLIC pbxsetting util plist)
 target_include_directories(xcworkspace PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/Headers")
+install(TARGETS xcworkspace DESTINATION lib)
 
 add_executable(dump_xcworkspace Tools/dump_xcworkspace.cpp)
 target_link_libraries(dump_xcworkspace xcworkspace xcscheme pbxproj util plist)

--- a/Makefile
+++ b/Makefile
@@ -9,21 +9,29 @@
 
 build := build
 project := project
+PREFIX := /
 
 cmake := cmake
 cmake_flags := 
+cmake_command := $(cmake) -H. $(cmake_flags)
 
 ninja := $(if $(shell which llbuild),llbuild ninja build,ninja)
 ninja_flags := $(if $(shell echo "$$NINJA_JOBS"),-j$(shell echo "$$NINJA_JOBS"),)
+ninja_command := $(ninja) $(ninja_flags)
 
 all:
 	mkdir -p $(build)
-	$(cmake) -B$(build) -H. -G Ninja $(cmake_flags)
-	$(ninja) -C $(build) $(ninja_flags)
+	$(cmake_command) -B$(build) -GNinja
+	$(ninja_command) -C $(build)
 
 project:
 	mkdir -p $(project)
-	$(cmake) -B$(project) -H. -G Xcode $(cmake_flags)
+	$(cmake_command) -B$(project) -GXcode
+
+install:
+	mkdir -p $(PREFIX)
+	$(cmake_command) -B$(build) -GNinja -DCMAKE_INSTALL_PREFIX:PATH=$(realpath $(PREFIX)) -DCMAKE_INSTALL_NAME_DIR:STRING=@executable_path/../lib
+	$(ninja_command) -C $(build) install
 
 test: all
 	set -e; for test in build/test_*; do echo; echo "$$test"; ./$$test; done


### PR DESCRIPTION
With this, using `make install PREFIX=/tmp`, the files output are:

    /tmp/lib/libacdriver.dylib
    /tmp/lib/libbom.dylib
    /tmp/lib/libbuiltin.dylib
    /tmp/lib/libcar.dylib
    /tmp/lib/libdependency.dylib
    /tmp/lib/libext.dylib
    /tmp/lib/libninja.dylib
    /tmp/lib/libpbxbuild.dylib
    /tmp/lib/libpbxproj.dylib
    /tmp/lib/libpbxsetting.dylib
    /tmp/lib/libpbxspec.dylib
    /tmp/lib/libplist.dylib
    /tmp/lib/libutil.dylib
    /tmp/lib/libxcassets.dylib
    /tmp/lib/libxcdriver.dylib
    /tmp/lib/libxcexecution.dylib
    /tmp/lib/libxcformatter.dylib
    /tmp/lib/libxcscheme.dylib
    /tmp/lib/libxcsdk.dylib
    /tmp/lib/libxcworkspace.dylib
    /tmp/bin/actool
    /tmp/bin/builtin-copy
    /tmp/bin/builtin-copyPlist
    /tmp/bin/builtin-copyStrings
    /tmp/bin/builtin-copyTiff
    /tmp/bin/builtin-embeddedBinaryValidationUtility
    /tmp/bin/builtin-infoPlistUtility
    /tmp/bin/builtin-lsRegisterURL
    /tmp/bin/builtin-productPackagingUtility
    /tmp/bin/builtin-validationUtility
    /tmp/bin/dependency-info-tool
    /tmp/bin/lsbom
    /tmp/bin/plutil
    /tmp/bin/xcbuild
    /tmp/bin/xcrun

Confirmed the install paths are set up correctly to run the binaries on OS X.