### PR TITLE
Fix broken calls to Filesystem::enumerateDirectory

### DIFF
--- a/Libraries/libutil/Sources/Filesystem.cpp
+++ b/Libraries/libutil/Sources/Filesystem.cpp
@@ -21,18 +21,16 @@ enumerateRecursive(
     std::string const &path,
     std::function<bool(std::string const &)> const &cb) const
 {
-    this->enumerateDirectory(path, [&](std::string const &filename) -> bool {
+    this->enumerateDirectory(path, [&](std::string const &filename) -> void {
         std::string full = path + "/" + filename;
         cb(full);
-        return true;
     });
 
-    this->enumerateDirectory(path, [&](std::string const &filename) -> bool {
+    this->enumerateDirectory(path, [&](std::string const &filename) -> void {
         std::string full = path + "/" + filename;
         if (this->isDirectory(full) && !this->isSymbolicLink(full)) {
             this->enumerateRecursive(full, cb);
         }
-        return true;
     });
 
     return true;

--- a/Libraries/libutil/Tests/test_MemoryFilesystem.cpp
+++ b/Libraries/libutil/Tests/test_MemoryFilesystem.cpp
@@ -272,7 +272,6 @@ TEST(MemoryFilesystem, EnumerateDirectory)
     std::vector<std::string> files;
     auto accumulate = [&files](std::string const &name) {
         files.push_back(name);
-        return true;
     };
 
     /* List root contents. */

--- a/Libraries/xcassets/Sources/Asset/Asset.cpp
+++ b/Libraries/xcassets/Sources/Asset/Asset.cpp
@@ -95,7 +95,7 @@ loadChildren(Filesystem const *filesystem, std::vector<std::shared_ptr<Asset>> *
 {
     bool error = false;
 
-    filesystem->enumerateDirectory(_path, [&](std::string const &fileName) -> bool {
+    filesystem->enumerateDirectory(_path, [&](std::string const &fileName) -> void {
         std::string path = _path + "/" + fileName;
 
         if (filesystem->isDirectory(path)) {
@@ -109,13 +109,11 @@ loadChildren(Filesystem const *filesystem, std::vector<std::shared_ptr<Asset>> *
             if (asset == nullptr) {
                 fprintf(stderr, "error: failed to load asset: %s\n", path.c_str());
                 error = true;
-                return true;
+                return;
             }
 
             children->push_back(asset);
         }
-
-        return true;
     });
 
     return !error;
@@ -126,13 +124,11 @@ hasChildren(libutil::Filesystem const *filesystem)
 {
     bool hasChildren = false;
 
-    filesystem->enumerateDirectory(_path, [this, filesystem, &hasChildren](std::string const &fileName) -> bool {
+    filesystem->enumerateDirectory(_path, [this, filesystem, &hasChildren](std::string const &fileName) -> void {
         std::string path = _path + "/" + fileName;
         if (filesystem->isDirectory(path)) {
             hasChildren = true;
         }
-
-        return true;
     });
 
     return hasChildren;

--- a/Libraries/xcexecution/Sources/Parameters.cpp
+++ b/Libraries/xcexecution/Sources/Parameters.cpp
@@ -121,9 +121,9 @@ OpenProject(Filesystem const *filesystem, ext::optional<std::string> const &proj
         bool multiple = false;
         std::string projectName;
 
-        filesystem->enumerateDirectory(directory, [&](std::string const &filename) -> bool {
+        filesystem->enumerateDirectory(directory, [&](std::string const &filename) -> void {
             if (FSUtil::GetFileExtension(filename) != "xcodeproj") {
-                return true;
+                return;
             }
 
             if (!projectName.empty()) {
@@ -131,7 +131,6 @@ OpenProject(Filesystem const *filesystem, ext::optional<std::string> const &proj
             }
 
             projectName = filename;
-            return true;
         });
 
         if (multiple) {

--- a/Libraries/xcscheme/Sources/SchemeGroup.cpp
+++ b/Libraries/xcscheme/Sources/SchemeGroup.cpp
@@ -60,9 +60,9 @@ Open(Filesystem const *filesystem, std::string const &basePath, std::string cons
     std::string schemePath;
 
     schemePath = path + "/xcshareddata/xcschemes";
-    filesystem->enumerateDirectory(schemePath, [&](std::string const &filename) -> bool {
+    filesystem->enumerateDirectory(schemePath, [&](std::string const &filename) -> void {
         if (FSUtil::GetFileExtension(filename) != "xcscheme") {
-            return true;
+            return;
         }
 
         std::string name = filename.substr(0, filename.find('.'));
@@ -76,15 +76,14 @@ Open(Filesystem const *filesystem, std::string const &basePath, std::string cons
         if (!group->_defaultScheme && name == group->name()) {
             group->_defaultScheme = scheme;
         }
-        return true;
     });
 
     std::string userName = SysUtil::GetUserName();
     if (!userName.empty()) {
         schemePath = path + "/xcuserdata/" + userName + ".xcuserdatad/xcschemes";
-        filesystem->enumerateDirectory(schemePath, [&](std::string const &filename) -> bool {
+        filesystem->enumerateDirectory(schemePath, [&](std::string const &filename) -> void {
             if (FSUtil::GetFileExtension(filename) != "xcscheme") {
-                return true;
+                return;
             }
 
             std::string name = filename.substr(0, filename.find('.'));
@@ -98,7 +97,6 @@ Open(Filesystem const *filesystem, std::string const &basePath, std::string cons
             if (!group->_defaultScheme && name == group->name()) {
                 group->_defaultScheme = scheme;
             }
-            return true;
         });
     }
 

--- a/Libraries/xcsdk/Sources/SDK/Manager.cpp
+++ b/Libraries/xcsdk/Sources/SDK/Manager.cpp
@@ -115,17 +115,15 @@ Open(Filesystem const *filesystem, std::string const &path)
     std::vector<std::shared_ptr<Toolchain>> toolchains;
 
     std::string toolchainsPath = path + "/Toolchains";
-    filesystem->enumerateDirectory(toolchainsPath, [&](std::string const &filename) -> bool {
+    filesystem->enumerateDirectory(toolchainsPath, [&](std::string const &filename) -> void {
         if (FSUtil::GetFileExtension(filename) != "xctoolchain") {
-            return true;
+            return;
         }
 
         auto toolchain = SDK::Toolchain::Open(filesystem, manager, toolchainsPath + "/" + filename);
         if (toolchain != nullptr) {
             toolchains.push_back(toolchain);
         }
-
-        return true;
     });
 
     manager->_toolchains = toolchains;
@@ -133,17 +131,15 @@ Open(Filesystem const *filesystem, std::string const &path)
     std::vector<std::shared_ptr<Platform>> platforms;
 
     std::string platformsPath = path + "/Platforms";
-    filesystem->enumerateDirectory(platformsPath, [&](std::string const &filename) -> bool {
+    filesystem->enumerateDirectory(platformsPath, [&](std::string const &filename) -> void {
         if (FSUtil::GetFileExtension(filename) != "platform") {
-            return true;
+            return;
         }
 
         auto platform = SDK::Platform::Open(filesystem, manager, platformsPath + "/" + filename);
         if (platform != nullptr) {
             platforms.push_back(platform);
         }
-
-        return true;
     });
 
     std::sort(platforms.begin(), platforms.end(), [](Platform::shared_ptr const &a, Platform::shared_ptr const &b) -> bool {

--- a/Libraries/xcsdk/Sources/SDK/Platform.cpp
+++ b/Libraries/xcsdk/Sources/SDK/Platform.cpp
@@ -290,15 +290,14 @@ Open(Filesystem const *filesystem, std::shared_ptr<Manager> manager, std::string
         // Lookup all the SDKs inside the platform
         //
         std::string sdksPath = platform->_path + "/Developer/SDKs";
-        filesystem->enumerateDirectory(sdksPath, [&](std::string const &filename) -> bool {
+        filesystem->enumerateDirectory(sdksPath, [&](std::string const &filename) -> void {
             if (FSUtil::GetFileExtension(filename) != "sdk") {
-                return true;
+                return;
             }
 
             if (auto target = Target::Open(filesystem, manager, platform, sdksPath + "/" + filename)) {
                 platform->_targets.push_back(target);
             }
-            return true;
         });
 
         std::sort(platform->_targets.begin(), platform->_targets.end(),


### PR DESCRIPTION
Several calls to Filesystem::enumerateDirectory gave a
function with the wrong return type. Change the return type
of these functions from 'bool' to 'void' to satisfy the
signature of enumerateDirectory.