### PR TITLE
Fix compilation with GCC 6 on Ubuntu

### DIFF
--- a/Libraries/libutil/Sources/Subprocess.cpp
+++ b/Libraries/libutil/Sources/Subprocess.cpp
@@ -97,7 +97,11 @@ execute(
         }
 
         if (work_dir != nullptr) {
-            ::chdir(work_dir);
+            int rc = ::chdir(work_dir);
+            if (rc == -1) {
+                ::perror("chdir");
+                ::_exit(1);
+            }
         }
 
         ::execve(path.c_str(), (char *const *)exec_args.data(), (char *const *)exec_env.data());

--- a/Libraries/libutil/Sources/SysUtil.cpp
+++ b/Libraries/libutil/Sources/SysUtil.cpp
@@ -52,12 +52,7 @@ EnvironmentVariables()
 }
 
 #if defined(__linux__)
-static char initialWorkingDirectory[PATH_MAX] = { 0 };
-__attribute__((constructor))
-static void InitializeInitialWorkingDirectory()
-{
-    getcwd(initialWorkingDirectory, sizeof(initialWorkingDirectory));
-}
+static std::string initialWorkingDirectory = FSUtil::GetCurrentDirectory();
 
 #if !(__GLIBC__ >= 2 && __GLIBC_MINOR__ >= 16)
 static char initialExecutablePath[PATH_MAX] = { 0 };
@@ -98,7 +93,7 @@ GetExecutablePath()
 #error Unsupported platform.
 #endif
 
-    std::string absolutePath = FSUtil::ResolveRelativePath(std::string(path), std::string(initialWorkingDirectory));
+    std::string absolutePath = FSUtil::ResolveRelativePath(std::string(path), initialWorkingDirectory);
     return FSUtil::NormalizePath(absolutePath);
 #else
 #error Unsupported platform.

--- a/Libraries/plist/Sources/Format/XMLWriter.cpp
+++ b/Libraries/plist/Sources/Format/XMLWriter.cpp
@@ -305,6 +305,7 @@ handleReal(Real const *real)
 
     rc = snprintf(buf, sizeof(buf), "%.17g", real->value());
     assert(rc < (int)sizeof(buf));
+    (void)rc;
 
     /* Write '<real>number</real>'. */
     if (!writeString("<real>", true)) {
@@ -326,6 +327,7 @@ handleInteger(Integer const *integer)
 
     rc = snprintf(buf, sizeof(buf), "%" PRId64, integer->value());
     assert(rc < (int)sizeof(buf));
+    (void)rc;
 
     /* Write '<integer>number</integer>'. */
     if (!writeString("<integer>", true)) {


### PR DESCRIPTION
Building GCC 6.1.1 on Ubuntu 14.04  detected two errors:

* The return values of some APIs were not checked, and
* The result of some variables were not used.

Fix these errors, allowing GCC 6 to build all of xcbuild.