### PR TITLE
Don't aliasing types improperly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti -fno-exceptions")
 # Enable all warnings.
 add_compile_options(-Wall -Werror)
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-  add_compile_options(-Wno-multichar -Wno-sign-compare -fno-strict-aliasing)
+  add_compile_options(-Wno-multichar -Wno-sign-compare)
 endif ()
 
 # Enable color diagnostics.

--- a/Libraries/pbxbuild/Sources/DerivedDataHash.cpp
+++ b/Libraries/pbxbuild/Sources/DerivedDataHash.cpp
@@ -40,18 +40,12 @@ overrideSettings() const
 }
 
 static uint64_t
-hton64(uint64_t v)
+ReadBigEndian8(uint8_t bytes[8])
 {
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-    v = ((v & 0x00000000000000FFULL) << 56) |
-        ((v & 0x000000000000FF00ULL) << 40) |
-        ((v & 0x0000000000FF0000ULL) << 24) |
-        ((v & 0x00000000FF000000ULL) <<  8) |
-        ((v & 0x000000FF00000000ULL) >>  8) |
-        ((v & 0x0000FF0000000000ULL) >> 24) |
-        ((v & 0x00FF000000000000ULL) >> 40) |
-        ((v & 0xFF00000000000000ULL) >> 56);
-#endif
+    uint64_t v = 0;
+    for (unsigned i = 0; i < 8; ++i) {
+        v |= static_cast<uint64_t>(bytes[8 - i - 1]) << (i * 8);
+    }
     return v;
 }
 
@@ -73,7 +67,7 @@ ComputeDerivedDataHash(std::string const &path)
     char hash_path[28];
     int counter;
 
-    uint64_t first_value = hton64(*reinterpret_cast<uint64_t *>(&digest[0]));
+    uint64_t first_value = ReadBigEndian8(digest);
     counter = 13;
     while (counter >= 0) {
         hash_path[counter] = 'a' + (first_value % 26);
@@ -81,7 +75,7 @@ ComputeDerivedDataHash(std::string const &path)
         counter--;
     }
 
-    uint64_t second_value = hton64(*reinterpret_cast<uint64_t *>(&digest[8]));
+    uint64_t second_value = ReadBigEndian8(&digest[8]);
     counter = 27;
     while (counter > 13) {
         hash_path[counter] = 'a' + (second_value % 26);

--- a/Libraries/pbxspec/Sources/Manager.cpp
+++ b/Libraries/pbxspec/Sources/Manager.cpp
@@ -54,8 +54,9 @@ findSpecifications(std::vector<std::string> const &domains, char const *type) co
             for (auto const &entry : _specifications) {
                 auto const &it = entry.second.find(type);
                 if (it != entry.second.end()) {
-                    typename T::vector domainSpecifications = reinterpret_cast <typename T::vector const &> (it->second);
-                    specifications.insert(specifications.end(), domainSpecifications.begin(), domainSpecifications.end());
+                    for (auto const &s : it->second) {
+                        specifications.emplace_back(std::static_pointer_cast<T>(s));
+                    }
                 }
             }
         } else {
@@ -63,8 +64,9 @@ findSpecifications(std::vector<std::string> const &domains, char const *type) co
             if (doit != _specifications.end()) {
                 auto const &it = doit->second.find(type);
                 if (it != doit->second.end()) {
-                    typename T::vector domainSpecifications = reinterpret_cast <typename T::vector const &> (it->second);
-                    specifications.insert(specifications.end(), domainSpecifications.begin(), domainSpecifications.end());
+                    for (auto const &s : it->second) {
+                        specifications.emplace_back(std::static_pointer_cast<T>(s));
+                    }
                 }
             }
         }

--- a/Libraries/plist/Sources/Format/ABPWriter.cpp
+++ b/Libraries/plist/Sources/Format/ABPWriter.cpp
@@ -90,13 +90,16 @@ __ABPWriteDate(ABPContext *context, Date const *date)
     /* Reference time is 2001/1/1 */
     static uint64_t const ReferenceTimestamp = 978307200;
     double at;
+    uint64_t value;
 
     /* Write object type. */
     if (!__ABPWriteByte(context, __ABPRecordTypeToByte(kABPRecordTypeDate, 0)))
         return false;
 
     at = date->unixTimeValue() - ReferenceTimestamp;
-    return __ABPWriteWord(context, 8, *(uint64_t const *)&at);
+    /* HACK(strager): We should not rely on C's representation of double. */
+    memcpy(&value, &at, 8);
+    return __ABPWriteWord(context, 8, value);
 }
 
 static bool
@@ -131,10 +134,12 @@ __ABPWriteReal(ABPContext *context, Real *real)
     float       value32 = value;
 
     if ((double)value32 == value) {
-        uvalue = *(uint32_t const *)&value32;
+        /* HACK(strager): We should not rely on C's representation of float. */
+        memcpy(&uvalue, &value32, 4);
         nbits = 2;
     } else {
-        uvalue = *(uint64_t const *)&value;
+        /* HACK(strager): We should not rely on C's representation of double. */
+        memcpy(&uvalue, &value, 8);
         nbits = 3;
     }
 


### PR DESCRIPTION
Drop GCC's -fno-strict-aliasing and fix the bugs caught by
GCC's diagnostics. (GCC's diagnostics only trigger if
CMAKE_BUILD_TYPE is Release, not Debug.) Verified with GCC
6.1.1 on Ubuntu 14.04.