### PR TITLE
Explicitly install pkg-config on Linux for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ matrix:
           packages:
             - gcc-4.8
             - g++-4.8
+            - pkg-config
             - libxml2-dev
             - ninja-build
             - cmake

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ xcbuild and [xctool](https://github.com/facebook/xctool) are both Xcode-compatib
 [![Build Status](https://travis-ci.org/facebook/xcbuild.svg?branch=master)](https://travis-ci.org/facebook/xcbuild)
 
 - Xcode 7 or later, on OS X.
-- GCC 4.8 or later, on Linux. `libxml2-dev` is also required.
+- GCC 4.8 or later, on Linux. `libxml2-dev` and `pkg-config` are also required.
 - [CMake](http://www.cmake.org) and [Ninja](https://martine.github.io/ninja/) (or [llbuild](https://github.com/apple/swift-llbuild)). 
   - With [Homebrew](http://brew.sh/): `brew install cmake ninja`
 


### PR DESCRIPTION
pkg-config is needed on Linux in order for CMake to detect
libxml2. Apparently, Travis has it installed by default, but
be explicit about our dependencies for further developers.