### PR TITLE
[xcdriver] Add `xcbuild -usage` action

### DIFF
--- a/Libraries/xcdriver/CMakeLists.txt
+++ b/Libraries/xcdriver/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(xcdriver SHARED
             Sources/ListAction.cpp
             Sources/ShowBuildSettingsAction.cpp
             Sources/ShowSDKsAction.cpp
+            Sources/UsageAction.cpp
             Sources/VersionAction.cpp
             )
 

--- a/Libraries/xcdriver/Headers/xcdriver/UsageAction.h
+++ b/Libraries/xcdriver/Headers/xcdriver/UsageAction.h
@@ -1,0 +1,34 @@
+/**
+ Copyright (c) 2016-present, Facebook, Inc.
+ All rights reserved.
+
+ This source code is licensed under the BSD-style license found in the
+ LICENSE file in the root directory of this source tree. An additional grant
+ of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#ifndef __xcdriver_UsageAction_h
+#define __xcdriver_UsageAction_h
+
+#include <xcdriver/Base.h>
+
+namespace libutil { class Filesystem; }
+
+namespace xcdriver {
+
+class Options;
+
+class UsageAction {
+private:
+    UsageAction();
+    ~UsageAction();
+
+public:
+    static int
+    Run(libutil::Filesystem const *filesystem, Options const &options);
+};
+
+}
+
+#endif // !__xcdriver_UsageAction_h
+

--- a/Libraries/xcdriver/Sources/Driver.cpp
+++ b/Libraries/xcdriver/Sources/Driver.cpp
@@ -15,6 +15,7 @@
 #include <xcdriver/ListAction.h>
 #include <xcdriver/ShowSDKsAction.h>
 #include <xcdriver/ShowBuildSettingsAction.h>
+#include <xcdriver/UsageAction.h>
 #include <xcdriver/VersionAction.h>
 #include <libutil/Filesystem.h>
 
@@ -54,8 +55,7 @@ Run(Filesystem *filesystem, std::vector<std::string> const &args)
         case Action::Version:
             return VersionAction::Run(filesystem, options);
         case Action::Usage:
-            fprintf(stderr, "warning: usage not implemented\n");
-            break;
+            return UsageAction::Run(filesystem, options);
         case Action::Help:
             fprintf(stderr, "warning: help not implemented\n");
             break;

--- a/Libraries/xcdriver/Sources/UsageAction.cpp
+++ b/Libraries/xcdriver/Sources/UsageAction.cpp
@@ -1,0 +1,93 @@
+/**
+ Copyright (c) 2016-present, Facebook, Inc.
+ All rights reserved.
+
+ This source code is licensed under the BSD-style license found in the
+ LICENSE file in the root directory of this source tree. An additional grant
+ of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#include <xcdriver/UsageAction.h>
+
+using xcdriver::UsageAction;
+using xcdriver::Options;
+using libutil::Filesystem;
+
+UsageAction::
+UsageAction()
+{
+}
+
+UsageAction::
+~UsageAction()
+{
+}
+
+int UsageAction::
+Run(Filesystem const *filesystem, Options const &options)
+{
+    // TODO: Perhaps have xcdriver/Tools/xcbuild.cpp pass the name of the
+    //       executable (`argv[0]`) to `xcdriver::Driver::Run()`? That way,
+    //       the `UsageAction` could display the name of the program, instead
+    //       of hardcoding "xcbuild".
+    printf("Usage: xcbuild [-project <projectname>] "
+               "[[-target <targetname>]...|-alltargets] "
+               "[-configuration <configurationname>] "
+               "[-arch <architecture>]... "
+               "[-sdk [<sdkname>|<sdkpath>]] "
+               "[-showBuildSettings] [<buildsetting>=<value>]... "
+               "[-formatter [default]] "
+               "[-executor [simple|ninja]] "
+               "[-generate] "
+               "[<buildaction>]...\n"
+
+           "       xcbuild [-project <projectname>] -scheme <schemeName> "
+               "[-destination <destinationspecifier>]... "
+               "[-configuration <configurationname>] "
+               "[-arch <architecture>]... "
+               "[-sdk [<sdkname>|<sdkpath>]] "
+               "[-showBuildSettings] "
+               "[<buildsetting>=<value>]... "
+               "[-formatter [default]] "
+               "[-executor [simple|ninja]] "
+               "[-generate] "
+               "[<buildaction>]...\n"
+
+           "       xcbuild -workspace <workspacename> -scheme <schemeName> "
+               "[-destination <destinationspecifier>]... "
+               "[-configuration <configurationname>] "
+               "[-arch <architecture>]... "
+               "[-sdk [<sdkname>|<sdkpath>]] "
+               "[-showBuildSettings] "
+               "[<buildsetting>=<value>]... "
+               "[-formatter [default]] "
+               "[-executor [simple|ninja]] "
+               "[-generate] "
+               "[<buildaction>]...\n"
+
+           "       xcbuild -version "
+               "[-sdk [<sdkfullpath>|<sdkname>] "
+               "[<infoitem>] ]\n"
+
+           "       xcbuild -list "
+               "[[-project <projectname>]|[-workspace <workspacename>]]\n"
+
+           "       xcbuild -showsdks\n"
+
+           "       xcbuild -exportArchive "
+               "-archivePath <xcarchivepath> "
+               "-exportPath <destinationpath> "
+               "-exportOptionsPlist <plistpath>\n"
+
+           "       xcbuild -exportLocalizations "
+               "-localizationPath <path> "
+               "-project <projectname> "
+               "[-exportLanguage <targetlanguage>...]\n"
+
+           "       xcbuild -importLocalizations "
+               "-localizationPath <path> "
+               "-project <projectname>\n\n");
+
+    return 0;
+}
+


### PR DESCRIPTION
This addresses https://github.com/facebook/xcbuild/issues/3 by implementing a `-usage` action. The output mirrors `xcodebuild` exactly, although `xcbuild -usage` prints three additional options for each build action: `-formatter`, `-executor`, and `-generate`.

---

Let me know if this is what you had in mind. I wonder if we could automatically generate the lists of options, as opposed to hardcoding them... 🤔