### PR TITLE
Add `-help` action. Fixes #2.

### DIFF
--- a/Libraries/xcdriver/CMakeLists.txt
+++ b/Libraries/xcdriver/CMakeLists.txt
@@ -13,10 +13,12 @@ add_library(xcdriver SHARED
             Sources/Options.cpp
             Sources/BuildAction.cpp
             Sources/FindAction.cpp
+            Sources/HelpAction.cpp
             Sources/LicenseAction.cpp
             Sources/ListAction.cpp
             Sources/ShowBuildSettingsAction.cpp
             Sources/ShowSDKsAction.cpp
+            Sources/Usage.cpp
             Sources/UsageAction.cpp
             Sources/VersionAction.cpp
             )

--- a/Libraries/xcdriver/Headers/xcdriver/HelpAction.h
+++ b/Libraries/xcdriver/Headers/xcdriver/HelpAction.h
@@ -1,0 +1,34 @@
+/**
+ Copyright (c) 2016-present, Facebook, Inc.
+ All rights reserved.
+
+ This source code is licensed under the BSD-style license found in the
+ LICENSE file in the root directory of this source tree. An additional grant
+ of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#ifndef __xcdriver_HelpAction_h
+#define __xcdriver_HelpAction_h
+
+#include <xcdriver/Base.h>
+
+namespace xcdriver {
+
+/*
+ * Prints usage, as well as explanations of each invocation option.
+ */
+class HelpAction {
+private:
+    HelpAction();
+    ~HelpAction();
+
+public:
+    static int
+    Run();
+};
+
+}
+
+#endif // !__xcdriver_HelpAction_h
+
+

--- a/Libraries/xcdriver/Headers/xcdriver/Usage.h
+++ b/Libraries/xcdriver/Headers/xcdriver/Usage.h
@@ -1,0 +1,21 @@
+/**
+ Copyright (c) 2016-present, Facebook, Inc.
+ All rights reserved.
+
+ This source code is licensed under the BSD-style license found in the
+ LICENSE file in the root directory of this source tree. An additional grant
+ of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#ifndef __xcdriver_Usage_h
+#define __xcdriver_Usage_h
+
+#include <xcdriver/Base.h>
+
+namespace xcdriver {
+
+std::string usage();
+
+}
+
+#endif // !__xcdriver_Usage_h

--- a/Libraries/xcdriver/Sources/Driver.cpp
+++ b/Libraries/xcdriver/Sources/Driver.cpp
@@ -12,6 +12,7 @@
 #include <xcdriver/Options.h>
 #include <xcdriver/BuildAction.h>
 #include <xcdriver/FindAction.h>
+#include <xcdriver/HelpAction.h>
 #include <xcdriver/LicenseAction.h>
 #include <xcdriver/ListAction.h>
 #include <xcdriver/ShowSDKsAction.h>
@@ -58,8 +59,7 @@ Run(Filesystem *filesystem, std::vector<std::string> const &args)
         case Action::Usage:
             return UsageAction::Run();
         case Action::Help:
-            fprintf(stderr, "warning: help not implemented\n");
-            break;
+            return HelpAction::Run();
         case Action::License:
             return LicenseAction::Run();
         case Action::CheckFirstLaunch:

--- a/Libraries/xcdriver/Sources/HelpAction.cpp
+++ b/Libraries/xcdriver/Sources/HelpAction.cpp
@@ -1,0 +1,222 @@
+/**
+ Copyright (c) 2016-present, Facebook, Inc.
+ All rights reserved.
+
+ This source code is licensed under the BSD-style license found in the
+ LICENSE file in the root directory of this source tree. An additional grant
+ of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#include <xcdriver/HelpAction.h>
+#include <xcdriver/Usage.h>
+#include <libutil/FSUtil.h>
+#include <libutil/SysUtil.h>
+
+using xcdriver::HelpAction;
+using xcdriver::usage;
+using libutil::FSUtil;
+using libutil::SysUtil;
+
+HelpAction::
+HelpAction()
+{
+}
+
+HelpAction::
+~HelpAction()
+{
+}
+
+int HelpAction::
+Run()
+{
+    fprintf(stdout, "%s", usage().c_str());
+
+    fprintf(stdout, "Options:\n");
+    fprintf(
+        stdout,
+        "    -usage                                      "
+        "print brief usage instructions\n");
+    fprintf(
+        stdout,
+        "    -help                                       "
+        "print complete usage instructions\n");
+    fprintf(
+        stdout,
+        "    -verbose                                    "
+        "print diagnostic messages and other detailed information when "
+        "performing an action\n");
+    fprintf(
+        stdout,
+        "    -license                                    "
+        "print license\n");
+    fprintf(
+        stdout,
+        "    -checkFirstLaunchStatus                     "
+        "not yet implemented\n");
+    fprintf(
+        stdout,
+        "    -formatter NAME                             "
+        "use the output formatter NAME. Currently only 'default' is "
+        "supported\n");
+    fprintf(
+        stdout,
+        "    -executor NAME                              "
+        "use the execution engine NAME. Currently 'ninja' and 'simple' are "
+        "supported\n");
+    fprintf(
+        stdout,
+        "    -generate                                   "
+        "specify that an execution engine based on generating another build "
+        "language should regenerate\n");
+    fprintf(
+        stdout,
+        "    -project NAME                               "
+        "build the project NAME\n");
+    fprintf(
+        stdout,
+        "    -target NAME                                "
+        "build the target NAME\n");
+    fprintf(
+        stdout,
+        "    -alltargets                                 "
+        "build all targets\n");
+    fprintf(
+        stdout,
+        "    -workspace NAME                             "
+        "build the workspace NAME\n");
+    fprintf(
+        stdout,
+        "    -scheme NAME                                "
+        "build the scheme NAME\n");
+    fprintf(
+        stdout,
+        "    -configuration NAME                         "
+        "use the build configuration NAME for building each target\n");
+    fprintf(
+        stdout,
+        "    -xcconfig PATH                              "
+        "apply the build settings defined in the file at PATH, overriding "
+        "any settings already specified elsewhere, such as the project file\n");
+    fprintf(
+        stdout,
+        "    -arch ARCH                                  "
+        "instead of building the architectures defined in the project, build "
+        "each target for the architecture ARCH\n");
+    fprintf(
+        stdout,
+        "    -sdk NAME|PATH                              "
+        "build using the SDK NAME, or using the SDK at the given PATH\n");
+    fprintf(
+        stdout,
+        "    -toolchain NAME                             "
+        "not yet implemented\n");
+    fprintf(
+        stdout,
+        "    -destination DESTINATIONSPECIFIER           "
+        "not yet implemented\n");
+    fprintf(
+        stdout,
+        "    -destination-timeout TIMEOUT                "
+        "not yet implemented\n");
+    fprintf(
+        stdout,
+        "    -parallelizeTargets                         "
+        "not yet implemented\n");
+    fprintf(
+        stdout,
+        "    -jobs NUMBER                                "
+        "not yet implemented\n");
+    fprintf(
+        stdout,
+        "    -dry-run                                    "
+        "print build output without producing any build products\n");
+    fprintf(
+        stdout,
+        "    -hideShellScriptEnvironment                 "
+        "not yet implemented\n");
+    fprintf(
+        stdout,
+        "    -showsdks                                   "
+        "print a list of the installed SDKs\n");
+    fprintf(
+        stdout,
+        "    -showBuildSettings                          "
+        "print the build settings and their values for the given target\n");
+    fprintf(
+        stdout,
+        "    -list                                       "
+        "print the targets and configurations for a given project, or the "
+        "schemes for a given workspace\n");
+    fprintf(
+        stdout,
+        "    -find-executable NAME                       "
+        "print the path to executable NAME in the provided SDK and toolchain\n");
+    fprintf(
+        stdout,
+        "    -find-library NAME                          "
+        "not yet implemented\n");
+    fprintf(
+        stdout,
+        "    -version                                    "
+        "print version, or the version of any SDKs specified using the "
+        "-sdk option\n");
+    fprintf(
+        stdout,
+        "    -enableAddressSanitizer YES|NO              "
+        "not yet implemented\n");
+    fprintf(
+        stdout,
+        "    -resultBundlePath PATH                      "
+        "not yet implemented\n");
+    fprintf(
+        stdout,
+        "    -derivedDataPath PATH                       "
+        "not yet implemented\n");
+    fprintf(
+        stdout,
+        "    -archivePath PATH                           "
+        "not yet implemented\n");
+    fprintf(
+        stdout,
+        "    -exportArchive                              "
+        "export an archive after building\n");
+    fprintf(
+        stdout,
+        "    -exportOptionsPlist PATH                    "
+        "not yet implemented\n");
+    fprintf(
+        stdout,
+        "    -enableCodeCoverage YES|NO                  "
+        "not yet implemented\n");
+    fprintf(
+        stdout,
+        "    -exportPath PATH                            "
+        "not yet implemented\n");
+    fprintf(
+        stdout,
+        "    -skipUnavailableActions                     "
+        "specifies that scheme actions that cannot be performed should be "
+        "skipped, instead of causing a failure\n");
+    fprintf(
+        stdout,
+        "    -exportLocalizations                        "
+        "not yet implemented\n");
+    fprintf(
+        stdout,
+        "    -importLocalizations                        "
+        "not yet implemented\n");
+    fprintf(
+        stdout,
+        "    -localizationPath                           "
+        "not yet implemented\n");
+    fprintf(
+        stdout,
+        "    -exportLanguage                             "
+        "not yet implemented\n");
+
+    fprintf(stdout, "\n");
+
+    return 0;
+}
+

--- a/Libraries/xcdriver/Sources/Usage.cpp
+++ b/Libraries/xcdriver/Sources/Usage.cpp
@@ -1,0 +1,85 @@
+/**
+ Copyright (c) 2016-present, Facebook, Inc.
+ All rights reserved.
+
+ This source code is licensed under the BSD-style license found in the
+ LICENSE file in the root directory of this source tree. An additional grant
+ of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#include <xcdriver/Usage.h>
+#include <libutil/FSUtil.h>
+#include <libutil/SysUtil.h>
+#include <sstream>
+
+using libutil::FSUtil;
+using libutil::SysUtil;
+
+std::string xcdriver::usage() {
+	std::string executable = FSUtil::GetBaseName(SysUtil::GetExecutablePath());
+
+	std::ostringstream result;
+	result << "Usage: " << executable << " [-project <projectname>] "
+              "[[-target <targetname>]...|-alltargets] "
+              "[-configuration <configurationname>] "
+              "[-arch <architecture>]... "
+              "[-sdk [<sdkname>|<sdkpath>]] "
+              "[-showBuildSettings] [<buildsetting>=<value>]... "
+              "[-formatter [default]] "
+              "[-executor [simple|ninja]] "
+              "[-generate] "
+              "[<buildaction>]..." << std::endl;
+
+    result << "       " << executable << " "
+    	"[-project <projectname>] -scheme <schemeName> "
+        "[-destination <destinationspecifier>]... "
+        "[-configuration <configurationname>] "
+        "[-arch <architecture>]... "
+        "[-sdk [<sdkname>|<sdkpath>]] "
+        "[-showBuildSettings] "
+        "[<buildsetting>=<value>]... "
+        "[-formatter [default]] "
+        "[-executor [simple|ninja]] "
+        "[-generate] "
+        "[<buildaction>]..." << std::endl;
+
+    result << "       " << executable << " "
+    	"-workspace <workspacename> -scheme <schemeName> "
+        "[-destination <destinationspecifier>]... "
+        "[-configuration <configurationname>] "
+        "[-arch <architecture>]... "
+        "[-sdk [<sdkname>|<sdkpath>]] "
+        "[-showBuildSettings] "
+        "[<buildsetting>=<value>]... "
+        "[-formatter [default]] "
+        "[-executor [simple|ninja]] "
+        "[-generate] "
+        "[<buildaction>]..." << std::endl;
+
+    result << "       " << executable << " -version "
+        "[-sdk [<sdkfullpath>|<sdkname>] "
+        "[<infoitem>] ]" << std::endl;
+
+    result << "       " << executable << " -list "
+        "[[-project <projectname>]|[-workspace <workspacename>]]" << std::endl;
+
+    result << "       " << executable << " -showsdks" << std::endl;
+
+    result << "       " << executable << " -exportArchive "
+        "-archivePath <xcarchivepath> "
+        "-exportPath <destinationpath> "
+        "-exportOptionsPlist <plistpath>" << std::endl;
+
+    result << "       " << executable << " -exportLocalizations "
+        "-localizationPath <path> "
+        "-project <projectname> "
+        "[-exportLanguage <targetlanguage>...]" << std::endl;
+
+    result << "       " << executable << " -importLocalizations "
+        "-localizationPath <path> "
+        "-project <projectname>" << std::endl;
+
+    result << std::endl;
+
+    return result.str();
+}

--- a/Libraries/xcdriver/Sources/UsageAction.cpp
+++ b/Libraries/xcdriver/Sources/UsageAction.cpp
@@ -8,10 +8,12 @@
  */
 
 #include <xcdriver/UsageAction.h>
+#include <xcdriver/Usage.h>
 #include <libutil/FSUtil.h>
 #include <libutil/SysUtil.h>
 
 using xcdriver::UsageAction;
+using xcdriver::usage;
 using libutil::FSUtil;
 using libutil::SysUtil;
 
@@ -28,95 +30,7 @@ UsageAction::
 int UsageAction::
 Run()
 {
-    std::string executable = FSUtil::GetBaseName(SysUtil::GetExecutablePath());
-
-    fprintf(
-        stdout,
-        "Usage: %s [-project <projectname>] "
-        "[[-target <targetname>]...|-alltargets] "
-        "[-configuration <configurationname>] "
-        "[-arch <architecture>]... "
-        "[-sdk [<sdkname>|<sdkpath>]] "
-        "[-showBuildSettings] [<buildsetting>=<value>]... "
-        "[-formatter [default]] "
-        "[-executor [simple|ninja]] "
-        "[-generate] "
-        "[<buildaction>]...\n",
-        executable.c_str());
-
-    fprintf(
-        stdout,
-        "       %s [-project <projectname>] -scheme <schemeName> "
-        "[-destination <destinationspecifier>]... "
-        "[-configuration <configurationname>] "
-        "[-arch <architecture>]... "
-        "[-sdk [<sdkname>|<sdkpath>]] "
-        "[-showBuildSettings] "
-        "[<buildsetting>=<value>]... "
-        "[-formatter [default]] "
-        "[-executor [simple|ninja]] "
-        "[-generate] "
-        "[<buildaction>]...\n",
-        executable.c_str());
-
-    fprintf(
-        stdout,
-        "       %s -workspace <workspacename> -scheme <schemeName> "
-        "[-destination <destinationspecifier>]... "
-        "[-configuration <configurationname>] "
-        "[-arch <architecture>]... "
-        "[-sdk [<sdkname>|<sdkpath>]] "
-        "[-showBuildSettings] "
-        "[<buildsetting>=<value>]... "
-        "[-formatter [default]] "
-        "[-executor [simple|ninja]] "
-        "[-generate] "
-        "[<buildaction>]...\n",
-        executable.c_str());
-
-    fprintf(
-        stdout,
-        "       %s -version "
-        "[-sdk [<sdkfullpath>|<sdkname>] "
-        "[<infoitem>] ]\n",
-        executable.c_str());
-
-    fprintf(
-        stdout,
-        "       %s -list "
-        "[[-project <projectname>]|[-workspace <workspacename>]]\n",
-        executable.c_str());
-
-    fprintf(
-        stdout,
-        "       %s -showsdks\n",
-        executable.c_str());
-
-    fprintf(
-        stdout,
-        "       %s -exportArchive "
-        "-archivePath <xcarchivepath> "
-        "-exportPath <destinationpath> "
-        "-exportOptionsPlist <plistpath>\n",
-        executable.c_str());
-
-    fprintf(
-        stdout,
-        "       %s -exportLocalizations "
-        "-localizationPath <path> "
-        "-project <projectname> "
-        "[-exportLanguage <targetlanguage>...]\n",
-        executable.c_str());
-
-    fprintf(
-        stdout,
-        "       %s -importLocalizations "
-        "-localizationPath <path> "
-        "-project <projectname>\n",
-        executable.c_str());
-
-    fprintf(stdout, "\n");
-
+    fprintf(stdout, "%s", usage().c_str());
     return 0;
 }
 


### PR DESCRIPTION
This addresses #2 by implementing a `-help` action. `-help` prints `-usage`, then lists explanations of each option. Options that are not yet implemented are clearly marked as such to avoid confusion.