### PR TITLE
[xcbuild] Fixes to build on Linux

### DIFF
--- a/Libraries/acdriver/Headers/acdriver/Result.h
+++ b/Libraries/acdriver/Headers/acdriver/Result.h
@@ -10,6 +10,7 @@
 #ifndef __acdriver_Result_h
 #define __acdriver_Result_h
 
+#include <memory>
 #include <string>
 #include <vector>
 #include <unordered_map>

--- a/Libraries/builtin/Sources/copyStrings/Driver.cpp
+++ b/Libraries/builtin/Sources/copyStrings/Driver.cpp
@@ -19,6 +19,8 @@
 #include <libutil/Filesystem.h>
 #include <libutil/FSUtil.h>
 
+#include <strings.h>
+
 using builtin::copyStrings::Driver;
 using builtin::copyStrings::Options;
 using libutil::Filesystem;

--- a/Libraries/libutil/Headers/libutil/Base.h
+++ b/Libraries/libutil/Headers/libutil/Base.h
@@ -12,6 +12,7 @@
 
 #include <algorithm>
 #include <functional>
+#include <memory>
 #include <string>
 
 namespace libutil {

--- a/Libraries/pbxbuild/Sources/FileTypeResolver.cpp
+++ b/Libraries/pbxbuild/Sources/FileTypeResolver.cpp
@@ -13,6 +13,7 @@
 #include <libutil/Wildcard.h>
 
 #include <fstream>
+#include <strings.h>
 
 using pbxbuild::FileTypeResolver;
 using pbxbuild::DirectedGraph;

--- a/Libraries/xcdriver/Sources/ListAction.cpp
+++ b/Libraries/xcdriver/Sources/ListAction.cpp
@@ -13,6 +13,8 @@
 #include <libutil/Filesystem.h>
 #include <libutil/FSUtil.h>
 
+#include <strings.h>
+
 using xcdriver::ListAction;
 using xcdriver::Options;
 using libutil::Filesystem;

--- a/Libraries/xcsdk/Sources/SDK/Manager.cpp
+++ b/Libraries/xcsdk/Sources/SDK/Manager.cpp
@@ -14,6 +14,8 @@
 #include <pbxsetting/Setting.h>
 #include <pbxsetting/Type.h>
 
+#include <algorithm>
+
 using xcsdk::Configuration;
 using xcsdk::SDK::Manager;
 using xcsdk::SDK::Platform;

--- a/Libraries/xcworkspace/Tools/dump_xcworkspace.cpp
+++ b/Libraries/xcworkspace/Tools/dump_xcworkspace.cpp
@@ -13,6 +13,7 @@
 #include <libutil/DefaultFilesystem.h>
 #include <libutil/Filesystem.h>
 
+#include <algorithm>
 #include <cstring>
 #include <cerrno>
 


### PR DESCRIPTION
For whatever reason, xcbuild couldn't find unique_ptr, strcmpcase, and other basic std:: functionality unless I included the headers.