### PR TITLE
[xcbuild] Check local user path for xcsdk configuration

### DIFF
--- a/Libraries/pbxbuild/Sources/Build/Environment.cpp
+++ b/Libraries/pbxbuild/Sources/Build/Environment.cpp
@@ -56,7 +56,7 @@ Default(Filesystem const *filesystem)
      */
     specManager->registerDomains(filesystem, pbxspec::Manager::DefaultDomains(*developerRoot));
 
-    auto configuration = xcsdk::Configuration::Load(filesystem, xcsdk::Configuration::DefaultPath());
+    auto configuration = xcsdk::Configuration::Load(filesystem, xcsdk::Configuration::DefaultPaths());
     auto sdkManager = xcsdk::SDK::Manager::Open(filesystem, *developerRoot, configuration);
     if (sdkManager == nullptr) {
         fprintf(stderr, "error: couldn't create SDK manager\n");

--- a/Libraries/xcdriver/Sources/FindAction.cpp
+++ b/Libraries/xcdriver/Sources/FindAction.cpp
@@ -38,7 +38,7 @@ Run(Filesystem const *filesystem, Options const &options)
         return 1;
     }
 
-    auto configuration = xcsdk::Configuration::Load(filesystem, xcsdk::Configuration::DefaultPath());
+    auto configuration = xcsdk::Configuration::Load(filesystem, xcsdk::Configuration::DefaultPaths());
     auto manager = xcsdk::SDK::Manager::Open(filesystem, *developerRoot, configuration);
     if (manager == nullptr) {
         fprintf(stderr, "error: unable to open developer directory\n");

--- a/Libraries/xcdriver/Sources/ShowSDKsAction.cpp
+++ b/Libraries/xcdriver/Sources/ShowSDKsAction.cpp
@@ -39,7 +39,7 @@ Run(Filesystem const *filesystem, Options const &options)
         return 1;
     }
 
-    auto configuration = xcsdk::Configuration::Load(filesystem, xcsdk::Configuration::DefaultPath());
+    auto configuration = xcsdk::Configuration::Load(filesystem, xcsdk::Configuration::DefaultPaths());
     auto manager = xcsdk::SDK::Manager::Open(filesystem, *developerRoot, configuration);
     if (manager == nullptr) {
         fprintf(stderr, "error: unable to open developer directory\n");

--- a/Libraries/xcdriver/Sources/VersionAction.cpp
+++ b/Libraries/xcdriver/Sources/VersionAction.cpp
@@ -46,7 +46,7 @@ Run(Filesystem const *filesystem, Options const &options)
             return 1;
         }
 
-        auto configuration = xcsdk::Configuration::Load(filesystem, xcsdk::Configuration::DefaultPath());
+        auto configuration = xcsdk::Configuration::Load(filesystem, xcsdk::Configuration::DefaultPaths());
         auto manager = xcsdk::SDK::Manager::Open(filesystem, *developerRoot, configuration);
         if (manager == nullptr) {
             fprintf(stderr, "error: unable to open developer directory\n");

--- a/Libraries/xcsdk/Headers/xcsdk/Configuration.h
+++ b/Libraries/xcsdk/Headers/xcsdk/Configuration.h
@@ -46,14 +46,16 @@ public:
 
 public:
     /*
-     * The default path for the configuration.
+     * The default paths for the configuration.
      */
-    static std::string DefaultPath();
+    static std::vector<std::string> DefaultPaths();
 
     /*
-     * Loads a configuration from the filesystem.
+     * Loads a configuration from the filesystem given a list of
+     * possible locations. The configuration loaded is the first valid
+     * location.
      */
-    static ext::optional<Configuration> Load(libutil::Filesystem const *filesystem, std::string const &path);
+    static ext::optional<Configuration> Load(libutil::Filesystem const *filesystem, std::vector<std::string> const &paths);
 };
 
 }

--- a/Libraries/xcsdk/Tests/test_Configuration.cpp
+++ b/Libraries/xcsdk/Tests/test_Configuration.cpp
@@ -29,7 +29,41 @@ TEST(Configuration, Load)
         }")),
     });
 
-    auto configuration = Configuration::Load(&filesystem, "/Configuration.plist");
+    auto configuration = Configuration::Load(&filesystem, {"/Configuration.plist"});
+    ASSERT_NE(configuration, ext::nullopt);
+    EXPECT_EQ(configuration->extraPlatformsPaths(), std::vector<std::string>({ "one", "three" }));
+    EXPECT_EQ(configuration->extraToolchainsPaths(), std::vector<std::string>({ "two", "four" }));
+}
+
+TEST(Configuration, LoadRealFile)
+{
+    auto filesystem = MemoryFilesystem({
+        MemoryFilesystem::Entry::File("Configuration.plist", Contents("{ \
+            ExtraPlatformsPaths = ( one, three ); \
+            ExtraToolchainsPaths = ( two, four ); \
+        }")),
+    });
+
+    auto configuration = Configuration::Load(&filesystem, {"/FakeConfiguration.plist", "/Configuration.plist"});
+    ASSERT_NE(configuration, ext::nullopt);
+    EXPECT_EQ(configuration->extraPlatformsPaths(), std::vector<std::string>({ "one", "three" }));
+    EXPECT_EQ(configuration->extraToolchainsPaths(), std::vector<std::string>({ "two", "four" }));
+}
+
+TEST(Configuration, LoadFirstValidFile)
+{
+    auto filesystem = MemoryFilesystem({
+        MemoryFilesystem::Entry::File("Configuration.plist", Contents("{ \
+            ExtraPlatformsPaths = ( one, three ); \
+            ExtraToolchainsPaths = ( two, four ); \
+        }")),
+        MemoryFilesystem::Entry::File("Configuration2.plist", Contents("{ \
+            ExtraPlatformsPaths = ( five, six ); \
+            ExtraToolchainsPaths = ( seven, eight ); \
+        }")),
+    });
+
+    auto configuration = Configuration::Load(&filesystem, {"/Configuration.plist", "/Configuration2.plist"});
     ASSERT_NE(configuration, ext::nullopt);
     EXPECT_EQ(configuration->extraPlatformsPaths(), std::vector<std::string>({ "one", "three" }));
     EXPECT_EQ(configuration->extraToolchainsPaths(), std::vector<std::string>({ "two", "four" }));

--- a/Libraries/xcsdk/Tools/xcrun.cpp
+++ b/Libraries/xcsdk/Tools/xcrun.cpp
@@ -299,7 +299,7 @@ main(int argc, char **argv)
         fprintf(stderr, "error: unable to find developer root\n");
         return -1;
     }
-    auto configuration = xcsdk::Configuration::Load(filesystem.get(), xcsdk::Configuration::DefaultPath());
+    auto configuration = xcsdk::Configuration::Load(filesystem.get(), xcsdk::Configuration::DefaultPaths());
     auto manager = xcsdk::SDK::Manager::Open(filesystem.get(), *developerRoot, configuration);
     if (manager == nullptr) {
         fprintf(stderr, "error: unable to load manager from '%s'\n", developerRoot->c_str());


### PR DESCRIPTION
Depending on whether the tool is run under root or the local user, check paths appropriate for each.