### PR TITLE
[xcbuild] Split Libraries/Specifications into separate install components

### DIFF
--- a/Libraries/CMakeLists.txt
+++ b/Libraries/CMakeLists.txt
@@ -7,6 +7,9 @@
 # of patent rights can be found in the PATENTS file in the same directory.
 #
 
+set(OLD_DEFAULT_COMPONENT ${CMAKE_INSTALL_DEFAULT_COMPONENT_NAME})
+set(CMAKE_INSTALL_DEFAULT_COMPONENT_NAME libraries)
+
 add_subdirectory(acdriver)
 add_subdirectory(builtin)
 add_subdirectory(dependency)
@@ -27,4 +30,6 @@ add_subdirectory(xcformatter)
 add_subdirectory(xcscheme)
 add_subdirectory(xcsdk)
 add_subdirectory(xcworkspace)
+
+set(CMAKE_INSTALL_DEFAULT_COMPONENT_NAME ${OLD_DEFAULT_COMPONENT})
 

--- a/Specifications/CMakeLists.txt
+++ b/Specifications/CMakeLists.txt
@@ -7,6 +7,9 @@
 # of patent rights can be found in the PATENTS file in the same directory.
 #
 
+set(OLD_DEFAULT_COMPONENT ${CMAKE_INSTALL_DEFAULT_COMPONENT_NAME})
+set(CMAKE_INSTALL_DEFAULT_COMPONENT_NAME specifications)
+
 add_subdirectory(BuildPhase)
 add_subdirectory(BuildRules)
 add_subdirectory(BuildSystem)
@@ -14,3 +17,5 @@ add_subdirectory(Compiler)
 add_subdirectory(FileType)
 add_subdirectory(Linker)
 add_subdirectory(Tool)
+
+set(CMAKE_INSTALL_DEFAULT_COMPONENT_NAME ${OLD_DEFAULT_COMPONENT})


### PR DESCRIPTION
Using components allows builds to install only the stuff it needs.