### PR TITLE
[RFC] Install support files in Developer/ and user programs in bin/

### DIFF
--- a/CMake/Install.cmake
+++ b/CMake/Install.cmake
@@ -7,9 +7,11 @@
 # of patent rights can be found in the PATENTS file in the same directory.
 #
 
+set(XCBUILD_INSTALL_DEVELOPER_DIR Developer CACHE STRING "Install path for xcbuild support files")
+
 # XCBUILD_INSTALL_TARGET(foo bar qix) installs the CMake targets 'foo', 'bar',
 # and 'qix' into the xcbuild Developer dir (specified by
-# CMAKE_INSTALL_PREFIX).
+# XCBUILD_INSTALL_DEVELOPER_DIR).
 function (XCBUILD_INSTALL_TARGET)
   cmake_parse_arguments("" "" "" "" ${ARGN})
   set(TARGETS ${_UNPARSED_ARGUMENTS})
@@ -17,6 +19,6 @@ function (XCBUILD_INSTALL_TARGET)
   # libraries (including Windows import libraries).
   # TODO(strager): Handle FRAMEWORK and BUNDLE targets.
   install(TARGETS ${TARGETS}
-          RUNTIME DESTINATION usr/bin
-          LIBRARY DESTINATION usr/lib)
+          RUNTIME DESTINATION ${XCBUILD_INSTALL_DEVELOPER_DIR}/usr/bin
+          LIBRARY DESTINATION ${XCBUILD_INSTALL_DEVELOPER_DIR}/usr/lib)
 endfunction ()

--- a/CMake/Install.cmake
+++ b/CMake/Install.cmake
@@ -1,0 +1,22 @@
+#
+# Copyright (c) 2015-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+#
+
+# XCBUILD_INSTALL_TARGET(foo bar qix) installs the CMake targets 'foo', 'bar',
+# and 'qix' into the xcbuild Developer dir (specified by
+# CMAKE_INSTALL_PREFIX).
+function (XCBUILD_INSTALL_TARGET)
+  cmake_parse_arguments("" "" "" "" ${ARGN})
+  set(TARGETS ${_UNPARSED_ARGUMENTS})
+  # ARCHIVE is deliberately omitted; intentionally do not install static
+  # libraries (including Windows import libraries).
+  # TODO(strager): Handle FRAMEWORK and BUNDLE targets.
+  install(TARGETS ${TARGETS}
+          RUNTIME DESTINATION usr/bin
+          LIBRARY DESTINATION usr/lib)
+endfunction ()

--- a/CMake/Install.cmake
+++ b/CMake/Install.cmake
@@ -12,8 +12,24 @@ set(XCBUILD_INSTALL_DEVELOPER_DIR Developer CACHE STRING "Install path for xcbui
 # XCBUILD_INSTALL_TARGET(foo bar qix) installs the CMake targets 'foo', 'bar',
 # and 'qix' into the xcbuild Developer dir (specified by
 # XCBUILD_INSTALL_DEVELOPER_DIR).
+#
+# If USER is specified, also install the targets into CMAKE_INSTALL_PREFIX.
+# Mutually exclusive with USER.
+#
+# If USER_ALIAS is specified, also install xcrun into CMAKE_INSTALL_PREFIX
+# renamed for each target. All targets must be executables. Mutually exclusive
+# with USER.
+#
+# USER_ALIAS allows users to easily access Developer dir tools without adding
+# Developer/usr/bin to $PATH. For example, XCBUILD_INSTALL_ALIAS(plutil USER)
+# will install xcrun into /usr/local/bin/plutil. Because xcrun inspects its file
+# name at runtime, xcrun will find and invoke ${DEVELOPER_DIR}/usr/bin/plutil.
 function (XCBUILD_INSTALL_TARGET)
-  cmake_parse_arguments("" "" "" "" ${ARGN})
+  cmake_parse_arguments("" "USER;USER_ALIAS" "" "" ${ARGN})
+  if (${_USER} AND ${_USER_ALIAS})
+    message(AUTHOR_WARNING "XCBUILD_INSTALL_TARGET was called with mutually exclusive options: USER and USER_ALIAS")
+    set(_USER_ALIAS False)
+  endif ()
   set(TARGETS ${_UNPARSED_ARGUMENTS})
   # ARCHIVE is deliberately omitted; intentionally do not install static
   # libraries (including Windows import libraries).
@@ -21,4 +37,71 @@ function (XCBUILD_INSTALL_TARGET)
   install(TARGETS ${TARGETS}
           RUNTIME DESTINATION ${XCBUILD_INSTALL_DEVELOPER_DIR}/usr/bin
           LIBRARY DESTINATION ${XCBUILD_INSTALL_DEVELOPER_DIR}/usr/lib)
+  if (${_USER})
+    install(TARGETS ${TARGETS}
+            RUNTIME DESTINATION bin
+            LIBRARY DESTINATION lib)
+  endif ()
+  if (${_USER_ALIAS})
+    foreach (TARGET ${TARGETS})
+      get_target_property(TYPE ${TARGET} TYPE)
+      if (${TYPE} STREQUAL EXECUTABLE)
+        # NOTE(strager): Assumes XCBUILD_INSTALL_TARGET(xcrun USER) was (or will
+        # be) called.
+        XCBUILD_INSTALL_PROGRAM_ALIAS(TARGET ${TARGET} ALIASED_TARGET xcrun DESTINATION bin)
+      else ()
+        message(AUTHOR_WARNING "XCBUILD_INSTALL_DEVELOPER_DIR cannot install non-executable (${TYPE}) target ${TARGET} with USER_ALIAS")
+      endif ()
+    endforeach ()
+  endif ()
+endfunction ()
+
+# XCBUILD_INSTALL_PROGRAM_ALIAS(ALIASED_TARGET a DESTINATION d TARGET t)
+# installs the 'a' target with the name of the 't' target in the 'd' directory.
+#
+# Assumes install(TARGETS t DESTINATION d) was (or will be) called.
+function (XCBUILD_INSTALL_PROGRAM_ALIAS)
+  # There are several ways to implement this, each with their own problems:
+  #
+  # * install(TARGETS). This does not support the RENAME option.
+  #   TODO(strager): Investigate this solution with hackily-duplicated targets.
+  #
+  # * install(PROGRAMS $<TARGET_FILE:>). install(PROGRAMS) does not post-process
+  #   the executable. RENAME does not support generator expressions.
+  #
+  # * install(CODE "file(INSTALL ... FILES
+  #           \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/..."\"). This requires
+  #   the aliased target be previously install()ed. install(CODE) does not
+  #   support generator expressions.
+  #
+  # * cmake -E create_symlink, install(PROGRAMS). Symlinks require the aliased
+  #   target to be eventually installed in the same destination. This does not
+  #   work on systems which do not support symlinks (e.g. NTFS (Windows)).
+  #
+  # Because xcbuild currently does not support Windows, use symlinks.
+  set(_ALIASED_TARGET)
+  set(_DESTINATION)
+  set(_TARGET)
+  cmake_parse_arguments("" "" "ALIASED_TARGET;DESTINATION;TARGET" "" ${ARGN})
+  if (${_UNPARSED_ARGUMENTS})
+    message(AUTHOR_WARNING "XCBUILD_INSTALL_PROGRAM_ALIAS does not recognize the following arguments: ${_UNPARSED_ARGUMENTS}")
+  endif ()
+  if (${_ALIASED_TARGET} STREQUAL "")
+    message(SEND_ERROR "XCBUILD_INSTALL_PROGRAM_ALIAS is missing the required ALIASED_TARGET option")
+    return ()
+  endif ()
+  if (${_DESTINATION} STREQUAL "")
+    message(SEND_ERROR "XCBUILD_INSTALL_PROGRAM_ALIAS is missing the required DESTINATION option")
+    return ()
+  endif ()
+  if (${_TARGET} STREQUAL "")
+    message(SEND_ERROR "XCBUILD_INSTALL_PROGRAM_ALIAS is missing the required TARGET option")
+    return ()
+  endif ()
+  set(TEMP_PATH ${CMAKE_CURRENT_BINARY_DIR}/xcbuild-alias/${ALIASED_TARGET})
+  set(TEMP_FILE ${TEMP_PATH}/$<TARGET_FILE_NAME:${_TARGET}>)
+  add_custom_command(TARGET ${_TARGET}
+                     COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_NAME:${_ALIASED_TARGET}> ${TEMP_PATH}
+                     COMMAND ${CMAKE_COMMAND} -E create_symlink $<TARGET_FILE_NAME:${_ALIASED_TARGET}> ${TEMP_FILE})
+  install(PROGRAMS ${TEMP_FILE} DESTINATION ${_DESTINATION})
 endfunction ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,9 @@
 project(xcbuild C CXX)
 
 cmake_minimum_required(VERSION 3.0)
+
+include(CMake/Install.cmake)
+
 set(CMAKE_MACOSX_RPATH 1)
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")

--- a/Libraries/acdriver/CMakeLists.txt
+++ b/Libraries/acdriver/CMakeLists.txt
@@ -20,12 +20,11 @@ add_library(acdriver SHARED
 
 target_link_libraries(acdriver PUBLIC xcassets util plist dependency ext bom car ${PNG_LIBRARIES})
 target_include_directories(acdriver PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/Headers")
-
-install(TARGETS acdriver DESTINATION usr/lib)
+XCBUILD_INSTALL_TARGET(acdriver)
 
 add_executable(actool Tools/actool.cpp)
 target_link_libraries(actool PRIVATE acdriver)
-install(TARGETS actool DESTINATION usr/bin)
+XCBUILD_INSTALL_TARGET(actool)
 
 if (BUILD_TESTING)
   ADD_UNIT_GTEST(acdriver Options Tests/test_Options.cpp)

--- a/Libraries/builtin/CMakeLists.txt
+++ b/Libraries/builtin/CMakeLists.txt
@@ -51,43 +51,43 @@ endif ()
 
 target_link_libraries(builtin PUBLIC util plist pbxsetting ${CORE_FOUNDATION} ${CORE_SERVICES})
 target_include_directories(builtin PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/Headers")
-install(TARGETS builtin DESTINATION usr/lib)
+XCBUILD_INSTALL_TARGET(builtin)
 
 add_executable(builtin-copy Tools/copy.cpp)
 target_link_libraries(builtin-copy builtin)
-install(TARGETS builtin-copy DESTINATION usr/bin)
+XCBUILD_INSTALL_TARGET(builtin-copy)
 
 add_executable(builtin-copyPlist Tools/copyPlist.cpp)
 target_link_libraries(builtin-copyPlist builtin)
-install(TARGETS builtin-copyPlist DESTINATION usr/bin)
+XCBUILD_INSTALL_TARGET(builtin-copyPlist)
 
 add_executable(builtin-copyStrings Tools/copyStrings.cpp)
 target_link_libraries(builtin-copyStrings builtin)
-install(TARGETS builtin-copyStrings DESTINATION usr/bin)
+XCBUILD_INSTALL_TARGET(builtin-copyStrings)
 
 add_executable(builtin-copyTiff Tools/copyTiff.cpp)
 target_link_libraries(builtin-copyTiff builtin)
-install(TARGETS builtin-copyTiff DESTINATION usr/bin)
+XCBUILD_INSTALL_TARGET(builtin-copyTiff)
 
 add_executable(builtin-infoPlistUtility Tools/infoPlistUtility.cpp)
 target_link_libraries(builtin-infoPlistUtility builtin)
-install(TARGETS builtin-infoPlistUtility DESTINATION usr/bin)
+XCBUILD_INSTALL_TARGET(builtin-infoPlistUtility)
 
 add_executable(builtin-lsRegisterURL Tools/lsRegisterURL.cpp)
 target_link_libraries(builtin-lsRegisterURL builtin)
-install(TARGETS builtin-lsRegisterURL DESTINATION usr/bin)
+XCBUILD_INSTALL_TARGET(builtin-lsRegisterURL)
 
 add_executable(builtin-productPackagingUtility Tools/productPackagingUtility.cpp)
 target_link_libraries(builtin-productPackagingUtility builtin)
-install(TARGETS builtin-productPackagingUtility DESTINATION usr/bin)
+XCBUILD_INSTALL_TARGET(builtin-productPackagingUtility)
 
 add_executable(builtin-validationUtility Tools/validationUtility.cpp)
 target_link_libraries(builtin-validationUtility builtin)
-install(TARGETS builtin-validationUtility DESTINATION usr/bin)
+XCBUILD_INSTALL_TARGET(builtin-validationUtility)
 
 add_executable(builtin-embeddedBinaryValidationUtility Tools/embeddedBinaryValidationUtility.cpp)
 target_link_libraries(builtin-embeddedBinaryValidationUtility builtin)
-install(TARGETS builtin-embeddedBinaryValidationUtility DESTINATION usr/bin)
+XCBUILD_INSTALL_TARGET(builtin-embeddedBinaryValidationUtility)
 
 if (BUILD_TESTING)
   ADD_UNIT_GTEST(builtin copyStrings Tests/test_copyStrings.cpp)

--- a/Libraries/dependency/CMakeLists.txt
+++ b/Libraries/dependency/CMakeLists.txt
@@ -17,11 +17,11 @@ add_library(dependency SHARED
 
 target_link_libraries(dependency PUBLIC util ext)
 target_include_directories(dependency PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/Headers")
-install(TARGETS dependency DESTINATION usr/lib)
+XCBUILD_INSTALL_TARGET(dependency)
 
 add_executable(dependency-info-tool Tools/dependency-info-tool.cpp)
 target_link_libraries(dependency-info-tool dependency util)
-install(TARGETS dependency-info-tool DESTINATION usr/bin)
+XCBUILD_INSTALL_TARGET(dependency-info-tool)
 
 if (BUILD_TESTING)
   ADD_UNIT_GTEST(dependency BinaryDependencyInfo Tests/test_BinaryDependencyInfo.cpp)

--- a/Libraries/ext/CMakeLists.txt
+++ b/Libraries/ext/CMakeLists.txt
@@ -13,5 +13,5 @@ add_library(ext SHARED
 
 target_link_libraries(ext PUBLIC)
 target_include_directories(ext PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/Headers")
-install(TARGETS ext DESTINATION usr/lib)
+XCBUILD_INSTALL_TARGET(ext)
 

--- a/Libraries/ext/CMakeLists.txt
+++ b/Libraries/ext/CMakeLists.txt
@@ -13,5 +13,5 @@ add_library(ext SHARED
 
 target_link_libraries(ext PUBLIC)
 target_include_directories(ext PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/Headers")
-XCBUILD_INSTALL_TARGET(ext)
+XCBUILD_INSTALL_TARGET(ext USER) # Used by xcrun.
 

--- a/Libraries/libbom/CMakeLists.txt
+++ b/Libraries/libbom/CMakeLists.txt
@@ -15,11 +15,11 @@ add_library(bom SHARED
 
 target_link_libraries(bom PUBLIC)
 target_include_directories(bom PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/Headers")
-install(TARGETS bom DESTINATION usr/lib)
+XCBUILD_INSTALL_TARGET(bom)
 
 add_executable(lsbom Tools/lsbom.cpp)
 target_link_libraries(lsbom PRIVATE util bom)
-install(TARGETS lsbom DESTINATION usr/bin)
+XCBUILD_INSTALL_TARGET(lsbom)
 
 add_executable(dump_bom Tools/dump_bom.c)
 target_link_libraries(dump_bom PRIVATE bom)

--- a/Libraries/libcar/CMakeLists.txt
+++ b/Libraries/libcar/CMakeLists.txt
@@ -27,7 +27,7 @@ endif ()
 
 target_link_libraries(car PUBLIC ext bom ${COMPRESSION})
 target_include_directories(car PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/Headers")
-install(TARGETS car DESTINATION usr/lib)
+XCBUILD_INSTALL_TARGET(car)
 
 add_executable(dump_car Tools/dump_car.cpp)
 target_link_libraries(dump_car PRIVATE car)

--- a/Libraries/libutil/CMakeLists.txt
+++ b/Libraries/libutil/CMakeLists.txt
@@ -25,7 +25,7 @@ add_library(util SHARED
 
 target_link_libraries(util PUBLIC ext)
 target_include_directories(util PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/Headers")
-install(TARGETS util DESTINATION usr/lib)
+XCBUILD_INSTALL_TARGET(util)
 
 if (BUILD_TESTING)
   ADD_UNIT_GTEST(util MemoryFilesystem Tests/test_MemoryFilesystem.cpp)

--- a/Libraries/libutil/CMakeLists.txt
+++ b/Libraries/libutil/CMakeLists.txt
@@ -25,7 +25,7 @@ add_library(util SHARED
 
 target_link_libraries(util PUBLIC ext)
 target_include_directories(util PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/Headers")
-XCBUILD_INSTALL_TARGET(util)
+XCBUILD_INSTALL_TARGET(util USER) # Used by xcrun.
 
 if (BUILD_TESTING)
   ADD_UNIT_GTEST(util MemoryFilesystem Tests/test_MemoryFilesystem.cpp)

--- a/Libraries/ninja/CMakeLists.txt
+++ b/Libraries/ninja/CMakeLists.txt
@@ -14,7 +14,7 @@ add_library(ninja SHARED
 
 target_link_libraries(ninja PUBLIC)
 target_include_directories(ninja PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/Headers")
-install(TARGETS ninja DESTINATION usr/lib)
+XCBUILD_INSTALL_TARGET(ninja)
 
 if (BUILD_TESTING)
   ADD_UNIT_GTEST(ninja Value Tests/test_Value.cpp)

--- a/Libraries/pbxbuild/CMakeLists.txt
+++ b/Libraries/pbxbuild/CMakeLists.txt
@@ -63,7 +63,7 @@ add_library(pbxbuild SHARED
 
 target_link_libraries(pbxbuild PUBLIC xcsdk xcworkspace xcscheme pbxproj pbxspec pbxsetting dependency util plist ext)
 target_include_directories(pbxbuild PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/Headers")
-install(TARGETS pbxbuild DESTINATION usr/lib)
+XCBUILD_INSTALL_TARGET(pbxbuild)
 
 add_executable(dump_hmap Tools/dump_hmap.cpp)
 target_link_libraries(dump_hmap pbxbuild util plist)

--- a/Libraries/pbxproj/CMakeLists.txt
+++ b/Libraries/pbxproj/CMakeLists.txt
@@ -44,7 +44,7 @@ add_library(pbxproj SHARED
 target_link_libraries(pbxproj PUBLIC pbxsetting util plist)
 target_include_directories(pbxproj PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/Headers")
 target_include_directories(pbxproj PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/PrivateHeaders")
-install(TARGETS pbxproj DESTINATION usr/lib)
+XCBUILD_INSTALL_TARGET(pbxproj)
 
 add_executable(dump_xcodeproj Tools/dump_xcodeproj.cpp)
 target_link_libraries(dump_xcodeproj pbxproj xcscheme pbxsetting util plist)

--- a/Libraries/pbxsetting/CMakeLists.txt
+++ b/Libraries/pbxsetting/CMakeLists.txt
@@ -23,7 +23,7 @@ add_library(pbxsetting SHARED
 target_link_libraries(pbxsetting PUBLIC util plist)
 target_include_directories(pbxsetting PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/Headers")
 target_include_directories(pbxsetting PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/PrivateHeaders")
-install(TARGETS pbxsetting DESTINATION usr/lib)
+XCBUILD_INSTALL_TARGET(pbxsetting)
 
 add_executable(dump_xcconfig Tools/dump_xcconfig.cpp)
 target_link_libraries(dump_xcconfig pbxsetting util)

--- a/Libraries/pbxsetting/CMakeLists.txt
+++ b/Libraries/pbxsetting/CMakeLists.txt
@@ -23,7 +23,7 @@ add_library(pbxsetting SHARED
 target_link_libraries(pbxsetting PUBLIC util plist)
 target_include_directories(pbxsetting PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/Headers")
 target_include_directories(pbxsetting PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/PrivateHeaders")
-XCBUILD_INSTALL_TARGET(pbxsetting)
+XCBUILD_INSTALL_TARGET(pbxsetting USER) # Used by xcrun.
 
 add_executable(dump_xcconfig Tools/dump_xcconfig.cpp)
 target_link_libraries(dump_xcconfig pbxsetting util)

--- a/Libraries/pbxspec/CMakeLists.txt
+++ b/Libraries/pbxspec/CMakeLists.txt
@@ -31,7 +31,7 @@ add_library(pbxspec SHARED
 target_link_libraries(pbxspec PUBLIC pbxsetting util plist ext)
 target_include_directories(pbxspec PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/Headers")
 target_include_directories(pbxspec PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/PrivateHeaders")
-install(TARGETS pbxspec DESTINATION usr/lib)
+XCBUILD_INSTALL_TARGET(pbxspec)
 
 add_executable(dump_xcspec Tools/dump_xcspec.cpp)
 target_link_libraries(dump_xcspec pbxspec)

--- a/Libraries/plist/CMakeLists.txt
+++ b/Libraries/plist/CMakeLists.txt
@@ -60,14 +60,14 @@ find_package(LibXml2 REQUIRED)
 target_include_directories(plist PRIVATE "${LIBXML2_INCLUDE_DIR}")
 target_link_libraries(plist PUBLIC ${LIBXML2_LIBRARIES})
 # TODO: Should we use the definitions from https://cmake.org/cmake/help/v3.0/module/FindLibXml2.html?
-install(TARGETS plist DESTINATION usr/lib)
+XCBUILD_INSTALL_TARGET(plist)
 
 target_include_directories(plist PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/Headers")
 target_include_directories(plist PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/PrivateHeaders")
 
 add_executable(plutil Tools/plutil.cpp)
 target_link_libraries(plutil plist util)
-install(TARGETS plutil DESTINATION usr/bin)
+XCBUILD_INSTALL_TARGET(plutil)
 
 if (BUILD_TESTING)
   ADD_UNIT_GTEST(plist Boolean Tests/test_Boolean.cpp)

--- a/Libraries/plist/CMakeLists.txt
+++ b/Libraries/plist/CMakeLists.txt
@@ -60,14 +60,14 @@ find_package(LibXml2 REQUIRED)
 target_include_directories(plist PRIVATE "${LIBXML2_INCLUDE_DIR}")
 target_link_libraries(plist PUBLIC ${LIBXML2_LIBRARIES})
 # TODO: Should we use the definitions from https://cmake.org/cmake/help/v3.0/module/FindLibXml2.html?
-XCBUILD_INSTALL_TARGET(plist)
+XCBUILD_INSTALL_TARGET(plist USER) # Used by xcrun.
 
 target_include_directories(plist PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/Headers")
 target_include_directories(plist PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/PrivateHeaders")
 
 add_executable(plutil Tools/plutil.cpp)
 target_link_libraries(plutil plist util)
-XCBUILD_INSTALL_TARGET(plutil)
+XCBUILD_INSTALL_TARGET(plutil USER_ALIAS)
 
 if (BUILD_TESTING)
   ADD_UNIT_GTEST(plist Boolean Tests/test_Boolean.cpp)

--- a/Libraries/xcassets/CMakeLists.txt
+++ b/Libraries/xcassets/CMakeLists.txt
@@ -44,7 +44,7 @@ add_library(xcassets SHARED
 
 target_link_libraries(xcassets PUBLIC util plist ext)
 target_include_directories(xcassets PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/Headers")
-install(TARGETS xcassets DESTINATION usr/lib)
+XCBUILD_INSTALL_TARGET(xcassets)
 
 add_executable(dump_xcassets Tools/dump_xcassets.cpp)
 target_link_libraries(dump_xcassets PRIVATE xcassets)

--- a/Libraries/xcdriver/CMakeLists.txt
+++ b/Libraries/xcdriver/CMakeLists.txt
@@ -33,11 +33,11 @@ target_include_directories(xcdriver PRIVATE "${CMAKE_CURRENT_BINARY_DIR}")
 
 target_link_libraries(xcdriver PUBLIC xcexecution xcformatter pbxbuild xcworkspace xcsdk pbxsetting util plist builtin)
 target_include_directories(xcdriver PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/Headers")
-install(TARGETS xcdriver DESTINATION usr/lib)
+XCBUILD_INSTALL_TARGET(xcdriver)
 
 add_executable(xcbuild Tools/xcbuild.cpp)
 target_link_libraries(xcbuild xcdriver)
-install(TARGETS xcbuild DESTINATION usr/bin)
+XCBUILD_INSTALL_TARGET(xcbuild)
 
 add_custom_command(TARGET xcbuild
                    COMMAND ${CMAKE_COMMAND} -E create_symlink $<TARGET_FILE_NAME:xcbuild> $<TARGET_FILE_DIR:xcbuild>/xcodebuild

--- a/Libraries/xcdriver/CMakeLists.txt
+++ b/Libraries/xcdriver/CMakeLists.txt
@@ -42,7 +42,7 @@ XCBUILD_INSTALL_TARGET(xcbuild)
 add_custom_command(TARGET xcbuild
                    COMMAND ${CMAKE_COMMAND} -E create_symlink $<TARGET_FILE_NAME:xcbuild> $<TARGET_FILE_DIR:xcbuild>/xcodebuild
                    DEPENDS $<TARGET_FILE:xcbuild>)
-install(FILES $<TARGET_FILE_DIR:xcbuild>/xcodebuild DESTINATION usr/bin)
+install(FILES $<TARGET_FILE_DIR:xcbuild>/xcodebuild DESTINATION ${XCBUILD_INSTALL_DEVELOPER_DIR}/usr/bin)
 
 if (BUILD_TESTING)
   ADD_UNIT_GTEST(xcdriver Options Tests/test_Options.cpp)

--- a/Libraries/xcexecution/CMakeLists.txt
+++ b/Libraries/xcexecution/CMakeLists.txt
@@ -17,4 +17,4 @@ add_library(xcexecution SHARED
 
 target_link_libraries(xcexecution PUBLIC xcformatter pbxbuild xcscheme xcworkspace pbxproj pbxsetting util dependency ninja builtin)
 target_include_directories(xcexecution PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/Headers")
-install(TARGETS xcexecution DESTINATION usr/lib)
+XCBUILD_INSTALL_TARGET(xcexecution)

--- a/Libraries/xcformatter/CMakeLists.txt
+++ b/Libraries/xcformatter/CMakeLists.txt
@@ -14,4 +14,4 @@ add_library(xcformatter SHARED
 
 target_link_libraries(xcformatter PUBLIC pbxbuild pbxproj pbxsetting)
 target_include_directories(xcformatter PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/Headers")
-install(TARGETS xcformatter DESTINATION usr/lib)
+XCBUILD_INSTALL_TARGET(xcformatter)

--- a/Libraries/xcscheme/CMakeLists.txt
+++ b/Libraries/xcscheme/CMakeLists.txt
@@ -30,4 +30,4 @@ add_library(xcscheme SHARED
 
 target_link_libraries(xcscheme PUBLIC pbxsetting util plist)
 target_include_directories(xcscheme PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/Headers")
-install(TARGETS xcscheme DESTINATION usr/lib)
+XCBUILD_INSTALL_TARGET(xcscheme)

--- a/Libraries/xcsdk/CMakeLists.txt
+++ b/Libraries/xcsdk/CMakeLists.txt
@@ -20,15 +20,15 @@ add_library(xcsdk SHARED
 
 target_link_libraries(xcsdk PUBLIC pbxsetting util plist)
 target_include_directories(xcsdk PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/Headers")
-install(TARGETS xcsdk DESTINATION usr/lib)
+XCBUILD_INSTALL_TARGET(xcsdk)
 
 add_executable(xcrun Tools/xcrun.cpp)
 target_link_libraries(xcrun xcsdk util)
-install(TARGETS xcrun DESTINATION usr/bin)
+XCBUILD_INSTALL_TARGET(xcrun)
 
 add_executable(xcode-select Tools/xcode-select.cpp)
 target_link_libraries(xcode-select xcsdk util)
-install(TARGETS xcode-select DESTINATION usr/bin)
+XCBUILD_INSTALL_TARGET(xcode-select)
 
 if (BUILD_TESTING)
   ADD_UNIT_GTEST(xcsdk PlatformVersion Tests/test_PlatformVersion.cpp)

--- a/Libraries/xcsdk/CMakeLists.txt
+++ b/Libraries/xcsdk/CMakeLists.txt
@@ -20,11 +20,11 @@ add_library(xcsdk SHARED
 
 target_link_libraries(xcsdk PUBLIC pbxsetting util plist)
 target_include_directories(xcsdk PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/Headers")
-XCBUILD_INSTALL_TARGET(xcsdk)
+XCBUILD_INSTALL_TARGET(xcsdk USER) # Used by xcrun.
 
 add_executable(xcrun Tools/xcrun.cpp)
 target_link_libraries(xcrun xcsdk util)
-XCBUILD_INSTALL_TARGET(xcrun)
+XCBUILD_INSTALL_TARGET(xcrun USER)
 
 add_executable(xcode-select Tools/xcode-select.cpp)
 target_link_libraries(xcode-select xcsdk util)

--- a/Libraries/xcsdk/Headers/xcsdk/SDK/Target.h
+++ b/Libraries/xcsdk/Headers/xcsdk/SDK/Target.h
@@ -32,7 +32,7 @@ public:
     typedef std::weak_ptr <Target> weak_ptr;
     typedef std::vector <shared_ptr> vector;
 
-protected:
+public:
     std::weak_ptr<Manager>  _manager;
     std::weak_ptr<Platform> _platform;
 

--- a/Libraries/xcsdk/Tools/xcrun.cpp
+++ b/Libraries/xcsdk/Tools/xcrun.cpp
@@ -329,75 +329,52 @@ main(int argc, char **argv)
      * Determine the SDK to use.
      */
     xcsdk::SDK::Target::shared_ptr target = manager->findTarget(SDK);
-    if (target == nullptr) {
-        fprintf(stderr, "error: unable to find sdk '%s'\n", SDK.c_str());
-        return -1;
-    }
     if (verbose) {
-        fprintf(stderr, "verbose: using sdk '%s': %s\n", target->canonicalName().c_str(), target->path().c_str());
-    }
-
-    /*
-     * Determine the toolchains to use. Default to the SDK's toolchains.
-     */
-    xcsdk::SDK::Toolchain::vector toolchains;
-    if (!toolchainsInput.empty()) {
-        /* If the custom toolchain exists, use it instead. */
-        std::vector<std::string> toolchainTokens = pbxsetting::Type::ParseList(toolchainsInput);
-        for (std::string const &toolchainToken : toolchainTokens) {
-            if (auto TC = manager->findToolchain(toolchainToken)) {
-                toolchains.push_back(TC);
-            }
+        if (target == nullptr) {
+            fprintf(stderr, "verbose: using no sdk\n");
+        } else {
+            fprintf(stderr, "verbose: using sdk '%s': %s\n", target->canonicalName().c_str(), target->path().c_str());
         }
-
-        if (toolchains.empty()) {
-            fprintf(stderr, "error: unable to find toolchains in '%s'\n", toolchainsInput.c_str());
-            return -1;
-        }
-    } else {
-        toolchains = target->toolchains();
-    }
-    if (toolchains.empty()) {
-        fprintf(stderr, "error: unable to find any toolchains\n");
-        return -1;
-    }
-    if (verbose) {
-        fprintf(stderr, "verbose: using toolchain(s):");
-        for (xcsdk::SDK::Toolchain::shared_ptr const &toolchain : toolchains) {
-            fprintf(stderr, " '%s'", toolchain->identifier().c_str());
-        }
-        fprintf(stderr, "\n");
     }
 
     /*
      * Perform actions.
      */
-    if (options.showSDKPath()) {
-        printf("%s\n", target->path().c_str());
-        return 0;
-    } else if (options.showSDKVersion()) {
-        printf("%s\n", target->path().c_str());
-        return 0;
-    } else if (options.showSDKBuildVersion()) {
-        if (auto product = target->product()) {
-            printf("%s\n", product->buildVersion().c_str());
+    if (options.showSDKPath() || options.showSDKVersion() || options.showSDKBuildVersion() || options.showSDKPlatformPath() || options.showSDKPlatformVersion()) {
+        if (target == nullptr) {
+            fprintf(stderr, "error: unable to find sdk '%s'\n", SDK.c_str());
+            return -1;
+        }
+        if (options.showSDKPath()) {
+            printf("%s\n", target->path().c_str());
             return 0;
+        } else if (options.showSDKVersion()) {
+            printf("%s\n", target->path().c_str());
+            return 0;
+        } else if (options.showSDKBuildVersion()) {
+            if (auto product = target->product()) {
+                printf("%s\n", product->buildVersion().c_str());
+                return 0;
+            } else {
+                fprintf(stderr, "error: sdk has no build version\n");
+                return -1;
+            }
+        } else if (options.showSDKPlatformPath()) {
+            if (auto platform = target->platform()) {
+                printf("%s\n", platform->path().c_str());
+            } else {
+                fprintf(stderr, "error: sdk has no platform\n");
+                return -1;
+            }
+        } else if (options.showSDKPlatformVersion()) {
+            if (auto platform = target->platform()) {
+                printf("%s\n", platform->version().c_str());
+            } else {
+                fprintf(stderr, "error: sdk has no platform\n");
+                return -1;
+            }
         } else {
-            fprintf(stderr, "error: sdk has no build version\n");
-            return -1;
-        }
-    } else if (options.showSDKPlatformPath()) {
-        if (auto platform = target->platform()) {
-            printf("%s\n", platform->path().c_str());
-        } else {
-            fprintf(stderr, "error: sdk has no platform\n");
-            return -1;
-        }
-    } else if (options.showSDKPlatformVersion()) {
-        if (auto platform = target->platform()) {
-            printf("%s\n", platform->version().c_str());
-        } else {
-            fprintf(stderr, "error: sdk has no platform\n");
+            assert(false);
             return -1;
         }
     } else {
@@ -406,9 +383,49 @@ main(int argc, char **argv)
         }
 
         /*
+         * Determine the toolchains to use. Default to the SDK's toolchains.
+         */
+        xcsdk::SDK::Toolchain::vector toolchains;
+        if (!toolchainsInput.empty()) {
+            /* If the custom toolchain exists, use it instead. */
+            std::vector<std::string> toolchainTokens = pbxsetting::Type::ParseList(toolchainsInput);
+            for (std::string const &toolchainToken : toolchainTokens) {
+                if (auto TC = manager->findToolchain(toolchainToken)) {
+                    toolchains.push_back(TC);
+                }
+            }
+
+            if (toolchains.empty()) {
+                fprintf(stderr, "error: unable to find toolchains in '%s'\n", toolchainsInput.c_str());
+                return -1;
+            }
+        } else if (target != nullptr) {
+            toolchains = target->toolchains();
+        }
+        if (target != nullptr && toolchains.empty()) {
+            fprintf(stderr, "error: unable to find any toolchains\n");
+            return -1;
+        }
+        if (verbose) {
+            fprintf(stderr, "verbose: using toolchain(s):");
+            for (xcsdk::SDK::Toolchain::shared_ptr const &toolchain : toolchains) {
+                fprintf(stderr, " '%s'", toolchain->identifier().c_str());
+            }
+            fprintf(stderr, "\n");
+        }
+
+        /*
          * Find the tool to execute in the SDK or toolchains.
          */
-        std::vector<std::string> executablePaths = target->executablePaths(toolchains);
+        std::vector<std::string> executablePaths;
+        if (target == nullptr) {
+            /* HACK(strager) */
+            xcsdk::SDK::Target t;
+            t._manager = manager;
+            executablePaths = t.executablePaths(toolchains);
+        } else {
+            executablePaths = target->executablePaths(toolchains);
+        }
         ext::optional<std::string> executable = filesystem->findExecutable(options.tool(), executablePaths);
         if (!executable) {
             fprintf(stderr, "error: tool '%s' not found\n", options.tool().c_str());
@@ -431,10 +448,12 @@ main(int argc, char **argv)
              * Update effective environment to include the target path.
              */
             std::unordered_map<std::string, std::string> environment = SysUtil::EnvironmentVariables();
-            environment["SYSROOT"] = target->path();
+            if (target != nullptr) {
+                environment["SYSROOT"] = target->path();
 
-            if (log) {
-                printf("env SDKROOT=%s %s\n", target->path().c_str(), executable->c_str());
+                if (log) {
+                    printf("env SDKROOT=%s %s\n", target->path().c_str(), executable->c_str());
+                }
             }
 
             /*

--- a/Libraries/xcworkspace/CMakeLists.txt
+++ b/Libraries/xcworkspace/CMakeLists.txt
@@ -16,7 +16,7 @@ add_library(xcworkspace SHARED
 
 target_link_libraries(xcworkspace PUBLIC pbxsetting util plist)
 target_include_directories(xcworkspace PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/Headers")
-install(TARGETS xcworkspace DESTINATION usr/lib)
+XCBUILD_INSTALL_TARGET(xcworkspace)
 
 add_executable(dump_xcworkspace Tools/dump_xcworkspace.cpp)
 target_link_libraries(dump_xcworkspace xcworkspace xcscheme pbxproj util plist)

--- a/Specifications/BuildPhase/CMakeLists.txt
+++ b/Specifications/BuildPhase/CMakeLists.txt
@@ -17,4 +17,4 @@ install(FILES
         com.apple.buildphase.rez.xcspec
         com.apple.buildphase.shellscript.xcspec
         com.apple.buildphase.sources.xcspec
-        DESTINATION Library/Xcode/Specifications)
+        DESTINATION ${XCBUILD_INSTALL_DEVELOPER_DIR}/Library/Xcode/Specifications)

--- a/Specifications/BuildRules/CMakeLists.txt
+++ b/Specifications/BuildRules/CMakeLists.txt
@@ -9,4 +9,4 @@
 
 install(FILES
         BuiltInBuildRules.plist
-        DESTINATION Library/Xcode/Specifications)
+        DESTINATION ${XCBUILD_INSTALL_DEVELOPER_DIR}/Library/Xcode/Specifications)

--- a/Specifications/BuildSystem/CMakeLists.txt
+++ b/Specifications/BuildSystem/CMakeLists.txt
@@ -13,4 +13,4 @@ install(FILES
         com.apple.build-system.jam.xcspec
         com.apple.build-system.native.xcspec
         com.apple.buildsettings.standard.xcspec
-        DESTINATION Library/Xcode/Specifications)
+        DESTINATION ${XCBUILD_INSTALL_DEVELOPER_DIR}/Library/Xcode/Specifications)

--- a/Specifications/Compiler/CMakeLists.txt
+++ b/Specifications/Compiler/CMakeLists.txt
@@ -15,4 +15,4 @@ install(FILES
         com.apple.compilers.gcc.xcspec
         com.apple.compilers.llvm.clang.1_0.compiler.xcspec
         com.apple.compilers.llvm.clang.1_0.xcspec
-        DESTINATION Library/Xcode/Specifications)
+        DESTINATION ${XCBUILD_INSTALL_DEVELOPER_DIR}/Library/Xcode/Specifications)

--- a/Specifications/FileType/CMakeLists.txt
+++ b/Specifications/FileType/CMakeLists.txt
@@ -178,4 +178,4 @@ install(FILES
         wrapper.xcmappingmodel.xcspec
         wrapper.xcspec
         wrapper.xpc-service.xcspec
-        DESTINATION Library/Xcode/Specifications)
+        DESTINATION ${XCBUILD_INSTALL_DEVELOPER_DIR}/Library/Xcode/Specifications)

--- a/Specifications/Linker/CMakeLists.txt
+++ b/Specifications/Linker/CMakeLists.txt
@@ -11,4 +11,4 @@ install(FILES
         com.apple.pbx.linkers.ld.xcspec
         com.apple.pbx.linkers.libtool.xcspec
         com.apple.xcode.linkers.lipo.xcspec
-        DESTINATION Library/Xcode/Specifications)
+        DESTINATION ${XCBUILD_INSTALL_DEVELOPER_DIR}/Library/Xcode/Specifications)

--- a/Specifications/Tool/CMakeLists.txt
+++ b/Specifications/Tool/CMakeLists.txt
@@ -20,4 +20,4 @@ install(FILES
         com.apple.tools.plutil.xcspec
         com.apple.tools.symlink.xcspec
         com.apple.tools.touch.xcspec
-        DESTINATION Library/Xcode/Specifications)
+        DESTINATION ${XCBUILD_INSTALL_DEVELOPER_DIR}/Library/Xcode/Specifications)


### PR DESCRIPTION
See individual commit messages for details.

Specific questions for the audience:

* Does supporting xcrun without an SDK make sense? (See "HACK/WIP Support xcrun without an SDK." commit.)
* I didn't realize xcrun won't necessarily use xcbuild's Developer directory. This makes the behaviour of the tools in ${CMAKE_INSTALL_PREFIX}/bin confusing to me. Is that a known problem or is it expected?
* Should we just install the user programs directly (duplicating them) instead of making aliases?
* Should I put the user programs in their own CMake install component? Currently they are in the "libraries" component.
* Will there ever be plans to support xcbuild as a set of APIs instead of a set of executables?
* What's a better name for "normal" installed files? I use "USER".
