### PR TITLE
Minor cleanups to image set compilation.

### DIFF
--- a/Libraries/acdriver/Headers/acdriver/CompileActionImageSet.h
+++ b/Libraries/acdriver/Headers/acdriver/CompileActionImageSet.h
@@ -7,22 +7,45 @@
  of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef __acdriver_CompileActionImageSet_h
+#define __acdriver_CompileActionImageSet_h
+
 #include <acdriver/CompileOutput.h>
 #include <acdriver/Result.h>
 
-#include <ext/optional>
-#include <car/Writer.h>
-
-#include <xcassets/Asset/Catalog.h>
+#include <xcassets/Asset/Asset.h>
 #include <xcassets/Asset/ImageSet.h>
 
-#include <string>
+#include <memory>
 
-bool
-CompileAsset(
-    xcassets::Asset::ImageSet::Image const &image,
-    std::shared_ptr<xcassets::Asset::Asset> const &parent,
-    libutil::Filesystem *filesystem,
-    acdriver::Options const &options,
-    acdriver::CompileOutput *compileOutput,
-    acdriver::Result *result);
+namespace acdriver {
+
+class CompileOutput;
+class Options;
+class Result;
+
+class CompileActionImageSet {
+private:
+    CompileActionImageSet();
+    ~CompileActionImageSet();
+
+public:
+    static bool Compile(
+        std::shared_ptr<xcassets::Asset::ImageSet> const &imageSet,
+        libutil::Filesystem *filesystem,
+        Options const &options,
+        CompileOutput *compileOutput,
+        Result *result);
+
+    static bool CompileAsset(
+        std::shared_ptr<xcassets::Asset::ImageSet> const &imageSet,
+        xcassets::Asset::ImageSet::Image const &image,
+        libutil::Filesystem *filesystem,
+        Options const &options,
+        CompileOutput *compileOutput,
+        Result *result);
+};
+
+}
+
+#endif // !__acdriver_CompileActionImageSet_h

--- a/Libraries/acdriver/Headers/acdriver/CompileOutput.h
+++ b/Libraries/acdriver/Headers/acdriver/CompileOutput.h
@@ -7,6 +7,9 @@
  of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef __acdriver_CompileOutput_h
+#define __acdriver_CompileOutput_h
+
 #include <plist/Dictionary.h>
 #include <dependency/BinaryDependencyInfo.h>
 #include <car/Writer.h>
@@ -16,9 +19,6 @@
 #include <utility>
 #include <vector>
 #include <ext/optional>
-
-#ifndef __acdriver_CompileOutput_h
-#define __acdriver_CompileOutput_h
 
 namespace libutil { class Filesystem; }
 

--- a/Libraries/acdriver/Sources/CompileAction.cpp
+++ b/Libraries/acdriver/Sources/CompileAction.cpp
@@ -42,6 +42,7 @@
 #include <plist/String.h>
 
 using acdriver::CompileAction;
+using acdriver::CompileActionImageSet;
 using acdriver::CompileOutput;
 using acdriver::Options;
 using acdriver::Output;
@@ -223,9 +224,7 @@ CompileAsset(
         }
         case xcassets::Asset::AssetType::ImageSet: {
             auto imageSet = std::static_pointer_cast<xcassets::Asset::ImageSet>(asset);
-            if (imageSet->images()) {
-                CompileChildren(*imageSet->images(), asset, filesystem, options, compileOutput, result);
-            }
+            CompileActionImageSet::Compile(imageSet, filesystem, options, compileOutput, result);
             break;
         }
         case xcassets::Asset::AssetType::ImageStack: {

--- a/Libraries/acdriver/Sources/CompileActionImageSet.cpp
+++ b/Libraries/acdriver/Sources/CompileActionImageSet.cpp
@@ -12,14 +12,14 @@
 #include <acdriver/Result.h>
 #include <xcassets/Asset/ImageSet.h>
 #include <xcassets/Slot/Idiom.h>
-#include <libutil/Filesystem.h>
-#include <libutil/FSUtil.h>
 #include <bom/bom.h>
 #include <car/Reader.h>
 #include <car/Writer.h>
 #include <car/Facet.h>
 #include <car/Rendition.h>
 #include <bom/bom_format.h>
+#include <libutil/Filesystem.h>
+#include <libutil/FSUtil.h>
 
 #include <algorithm>
 #include <fstream>
@@ -29,183 +29,183 @@
 #include <png.h>
 #include <string.h>
 
+using acdriver::CompileActionImageSet;
 using acdriver::CompileAction;
 using acdriver::CompileOutput;
 using acdriver::Options;
 using acdriver::Result;
-
 using libutil::FSUtil;
 
-static void png_user_read_data(png_structp png_ptr, png_bytep data, png_size_t length)
+static void
+png_user_read_data(png_structp png_ptr, png_bytep data, png_size_t length)
 {
-    unsigned char **contents_ptr = (unsigned char**)png_get_io_ptr(png_ptr);
-    if(!contents_ptr) {
+    unsigned char **contents_ptr = (unsigned char **)png_get_io_ptr(png_ptr);
+    if (contents_ptr == NULL) {
         return;
     }
+
     memcpy(data, *contents_ptr, length);
     *contents_ptr += length;
 }
 
-static bool readPNGFile(std::vector<unsigned char> &contents, std::string filename, std::vector<unsigned char> &pixels, size_t *width_out, size_t *height_out, size_t *channels_out, Result *result)
+static bool
+ReadPNGFile(
+    std::vector<unsigned char> &contents,
+    std::string const &filename,
+    std::vector<uint8_t> *pixels,
+    size_t *width_out,
+    size_t *height_out,
+    size_t *channels_out,
+    Result *result)
 {
-    png_struct *png_struct_ptr;
-    png_info *info_struct_ptr;
-
-    int number_of_passes;
-    png_uint_32 row_bytes;
-    png_byte **row_pointers = NULL;
-
-    if (png_sig_cmp(static_cast<png_const_bytep>(contents.data()), 0, 8)) {
+    if (contents.size() < 8 || png_sig_cmp(static_cast<png_const_bytep>(contents.data()), 0, 8)) {
         result->normal(
             Result::Severity::Error,
             "file is not a PNG file",
-            std::string(filename));
+            filename);
         return false;
     }
 
-    png_struct_ptr = png_create_read_struct(PNG_LIBPNG_VER_STRING, NULL, NULL, NULL);
-
-    if (!png_struct_ptr) {
+    png_struct *png_struct_ptr = png_create_read_struct(PNG_LIBPNG_VER_STRING, NULL, NULL, NULL);
+    if (png_struct_ptr == NULL) {
         result->normal(
             Result::Severity::Error,
             "png_create_read_struct returned error",
-            std::string(filename));
+            filename);
         return false;
     }
 
-    info_struct_ptr = png_create_info_struct(png_struct_ptr);
-    if (!info_struct_ptr) {
-        png_destroy_read_struct (&png_struct_ptr, NULL, NULL);
+    png_info *info_struct_ptr = png_create_info_struct(png_struct_ptr);
+    if (info_struct_ptr == NULL) {
+        png_destroy_read_struct(&png_struct_ptr, NULL, NULL);
         result->normal(
             Result::Severity::Error,
             "png_create_info_struct returned error",
-            std::string(filename));
+            filename);
         return false;
     }
 
     if (setjmp(png_jmpbuf(png_struct_ptr))) {
-        png_destroy_read_struct (&png_struct_ptr, &info_struct_ptr, NULL);
+        png_destroy_read_struct(&png_struct_ptr, &info_struct_ptr, NULL);
         result->normal(
             Result::Severity::Error,
             "setjmp/png_jmpbuf returned error",
-            std::string(filename));
+            filename);
         return false;
     }
 
-    unsigned char *contents_ptr = static_cast<unsigned char*>(contents.data());
+    unsigned char *contents_ptr = static_cast<unsigned char *>(contents.data());
     png_set_read_fn(png_struct_ptr, &contents_ptr, png_user_read_data);
 
     png_read_info(png_struct_ptr, info_struct_ptr);
 
     png_uint_32 width, height;
     int bit_depth, color_type, interlace_method, compression_method, filter_method, channels;
-    if (!png_get_IHDR (png_struct_ptr, info_struct_ptr,
-        &width, &height, &bit_depth, &color_type, &interlace_method, &compression_method, &filter_method)) {
-        png_destroy_read_struct (&png_struct_ptr, &info_struct_ptr, NULL);
+    if (!png_get_IHDR(png_struct_ptr, info_struct_ptr, &width, &height, &bit_depth, &color_type, &interlace_method, &compression_method, &filter_method)) {
+        png_destroy_read_struct(&png_struct_ptr, &info_struct_ptr, NULL);
         result->normal(
             Result::Severity::Error,
-            "setjmp/png_jmpbuf returned error",
-            std::string(filename));
+            "failed to read PNG header",
+            filename);
         return false;
     }
 
-    /* Convert pixels to RGBA or GA8 */
-    if (color_type == PNG_COLOR_TYPE_PALETTE) {
-        png_set_palette_to_rgb(png_struct_ptr);
-        png_set_bgr(png_struct_ptr);
-        png_set_filler(png_struct_ptr, 0xff, PNG_FILLER_AFTER);
-    }
-
-    if (color_type == PNG_COLOR_TYPE_GRAY &&
-        bit_depth < 8) {
-        png_set_expand_gray_1_2_4_to_8(png_struct_ptr);
-    }
-
+    /* Convert to a standard bit depth. */
     if (bit_depth == 16) {
         png_set_strip_16(png_struct_ptr);
+    } else if (bit_depth < 8) {
+        if (color_type == PNG_COLOR_TYPE_GRAY) {
+            png_set_expand_gray_1_2_4_to_8(png_struct_ptr);
+        } else {
+            png_set_packing(png_struct_ptr);
+        }
     }
 
-    if (bit_depth < 8) {
-        png_set_packing(png_struct_ptr);
-    }
-
-    if (color_type == PNG_COLOR_TYPE_RGB ||
-        color_type == PNG_COLOR_TYPE_RGB_ALPHA) {
-        png_set_bgr(png_struct_ptr);
-    }
-
-    if (color_type == PNG_COLOR_TYPE_RGB || color_type == PNG_COLOR_TYPE_GRAY) {
-        png_set_filler(png_struct_ptr, 0xff, PNG_FILLER_AFTER);
+    /* Convert pixels to RGBA or GA8. */
+    switch (color_type) {
+        case PNG_COLOR_TYPE_PALETTE:
+            png_set_palette_to_rgb(png_struct_ptr);
+            png_set_bgr(png_struct_ptr);
+            png_set_filler(png_struct_ptr, 0xff, PNG_FILLER_AFTER);
+            break;
+        case PNG_COLOR_TYPE_GRAY:
+            png_set_filler(png_struct_ptr, 0xff, PNG_FILLER_AFTER);
+            break;
+        case PNG_COLOR_TYPE_RGB:
+            png_set_bgr(png_struct_ptr);
+            png_set_filler(png_struct_ptr, 0xff, PNG_FILLER_AFTER);
+            break;
+        case PNG_COLOR_TYPE_RGB_ALPHA:
+            png_set_bgr(png_struct_ptr);
+            break;
     }
 
     png_set_alpha_mode(png_struct_ptr, PNG_ALPHA_PREMULTIPLIED, PNG_DEFAULT_sRGB);
 
-    number_of_passes = png_set_interlace_handling(png_struct_ptr);
-    (void) number_of_passes;
+    /* Handle interlaced images. */
+    (void)png_set_interlace_handling(png_struct_ptr);
 
-    /* Make transforms take effect */
+    /* Apply transforms. */
     png_read_update_info(png_struct_ptr, info_struct_ptr);
 
-    if (!png_get_IHDR (png_struct_ptr, info_struct_ptr,
-        &width, &height, &bit_depth, &color_type, &interlace_method, &compression_method, &filter_method)) {
-        png_destroy_read_struct (&png_struct_ptr, &info_struct_ptr, NULL);
+    if (!png_get_IHDR(png_struct_ptr, info_struct_ptr, &width, &height, &bit_depth, &color_type, &interlace_method, &compression_method, &filter_method)) {
+        png_destroy_read_struct(&png_struct_ptr, &info_struct_ptr, NULL);
         result->normal(
             Result::Severity::Error,
             "png_get_IHDR returned error",
-            std::string(filename));
+            filename);
         return false;
     }
 
     /* color_type will still show original format */
-    switch(color_type) {
+    switch (color_type) {
         case PNG_COLOR_TYPE_GRAY:
-            /* This is transformed to GA8 */
+            /* This is transformed to GA8. */
         case PNG_COLOR_TYPE_GRAY_ALPHA:
             channels = 2;
             break;
         case PNG_COLOR_TYPE_PALETTE:
         case PNG_COLOR_TYPE_RGB:
-            /* These are transformed to RGBA */
+            /* These are transformed to RGBA. */
         case PNG_COLOR_TYPE_RGB_ALPHA:
             channels = 4;
             break;
         default:
-            png_destroy_read_struct (&png_struct_ptr, &info_struct_ptr, NULL);
+            png_destroy_read_struct(&png_struct_ptr, &info_struct_ptr, NULL);
             result->normal(
                 Result::Severity::Error,
                 "Unhandled PNG color type");
             return false;
     }
 
-    row_bytes = png_get_rowbytes (png_struct_ptr, info_struct_ptr);
-    if (row_bytes != (width * (bit_depth/8) * channels)) {
-        png_destroy_read_struct (&png_struct_ptr, &info_struct_ptr, NULL);
+    png_uint_32 row_bytes = png_get_rowbytes(png_struct_ptr, info_struct_ptr);
+    if (row_bytes != (width * (bit_depth / 8) * channels)) {
+        png_destroy_read_struct(&png_struct_ptr, &info_struct_ptr, NULL);
         result->normal(
             Result::Severity::Error,
             "Unable to transform PNG pixel data");
         return false;
     }
 
-    row_pointers = (png_byte **) malloc (height * sizeof (png_bytep));
-    if (row_pointers == NULL)
-    {
-        png_destroy_read_struct (&png_struct_ptr, &info_struct_ptr, NULL);
+    png_byte **row_pointers = (png_byte **)malloc(height * sizeof(png_bytep));
+    if (row_pointers == NULL) {
+        png_destroy_read_struct(&png_struct_ptr, &info_struct_ptr, NULL);
         result->normal(
             Result::Severity::Error,
             "Could not allocate memory");
         return false;
     }
 
-    pixels = std::vector<unsigned char>(width * height * channels);
-    unsigned char *bytes = static_cast<unsigned char *>(pixels.data());
+    *pixels = std::vector<uint8_t>(width * height * channels);
+    unsigned char *bytes = static_cast<unsigned char *>(pixels->data());
     for (int row = 0; row < height; row++) {
         row_pointers[row] = bytes + (row * row_bytes);
     }
     png_read_image(png_struct_ptr, row_pointers);
 
-    /* clean up */
-    png_read_end (png_struct_ptr, info_struct_ptr);
-    png_destroy_read_struct (&png_struct_ptr, &info_struct_ptr, (png_infopp) NULL);
+    /* Clean up. */
+    png_read_end(png_struct_ptr, info_struct_ptr);
+    png_destroy_read_struct(&png_struct_ptr, &info_struct_ptr, (png_infopp)NULL);
     free(row_pointers);
 
     if (width_out) {
@@ -221,75 +221,183 @@ static bool readPNGFile(std::vector<unsigned char> &contents, std::string filena
 }
 
 static uint16_t
+IdiomAttributeForIdiom(xcassets::Slot::Idiom assetIdiom)
+{
+    switch (assetIdiom) {
+        case xcassets::Slot::Idiom::Universal:
+            return car_attribute_identifier_idiom_value_universal;
+            break;
+        case xcassets::Slot::Idiom::Phone:
+            return car_attribute_identifier_idiom_value_phone;
+            break;
+        case xcassets::Slot::Idiom::Pad:
+            return car_attribute_identifier_idiom_value_pad;
+            break;
+        case xcassets::Slot::Idiom::Desktop:
+            // TODO: desktop has no idiom value
+            return car_attribute_identifier_idiom_value_universal;
+        case xcassets::Slot::Idiom::TV:
+            return car_attribute_identifier_idiom_value_tv;
+        case xcassets::Slot::Idiom::Watch:
+            return car_attribute_identifier_idiom_value_watch;
+        case xcassets::Slot::Idiom::Car:
+            return car_attribute_identifier_idiom_value_car;
+        default:
+            return car_attribute_identifier_idiom_value_universal;
+    }
+}
+
+static enum car_rendition_value_layout
+LayoutForResizingAndCenterMode(xcassets::Resizing::Mode resizingMode, xcassets::Resizing::Center::Mode centerMode)
+{
+    switch (resizingMode) {
+        case xcassets::Resizing::Mode::ThreePartHorizontal:
+            switch (centerMode) {
+                case xcassets::Resizing::Center::Mode::Tile:
+                    return car_rendition_value_layout_three_part_horizontal_tile;
+                case xcassets::Resizing::Center::Mode::Stretch:
+                    return car_rendition_value_layout_three_part_horizontal_scale;
+                default:
+                    return car_rendition_value_layout_three_part_horizontal_tile;
+            }
+        case xcassets::Resizing::Mode::ThreePartVertical:
+            switch (centerMode) {
+                case xcassets::Resizing::Center::Mode::Tile:
+                    return car_rendition_value_layout_three_part_vertical_tile;
+                case xcassets::Resizing::Center::Mode::Stretch:
+                    return car_rendition_value_layout_three_part_vertical_scale;
+                default:
+                    return car_rendition_value_layout_three_part_vertical_tile;
+            }
+        case xcassets::Resizing::Mode::NinePart:
+            switch (centerMode) {
+                case xcassets::Resizing::Center::Mode::Tile:
+                    return car_rendition_value_layout_nine_part_tile;
+                case xcassets::Resizing::Center::Mode::Stretch:
+                    return car_rendition_value_layout_nine_part_scale;
+                default:
+                    return car_rendition_value_layout_nine_part_tile;
+            }
+        default: abort();
+    }
+}
+
+static std::vector<car::Rendition::Slice>
+SlicesForResizingModeAndCapInsets(uint32_t width, uint32_t height, xcassets::Resizing::Mode resizingMode, ext::optional<xcassets::Insets> const &capInsets)
+{
+    double topCapInset = capInsets ? capInsets->top().value_or(0) : 0;
+    double leftCapInset = capInsets ? capInsets->left().value_or(0) : 0;
+    double bottomCapInset = capInsets ? capInsets->bottom().value_or(0) : 0;
+    double rightCapInset = capInsets ? capInsets->right().value_or(0) : 0;
+
+    uint32_t leftWidth = static_cast<uint32_t>(leftCapInset);
+    uint32_t centerWidth = static_cast<uint32_t>(width - (leftCapInset + rightCapInset));
+    uint32_t rightWidth = static_cast<uint32_t>(rightCapInset);
+
+    uint32_t topHeight = static_cast<uint32_t>(topCapInset);
+    uint32_t centerHeight = static_cast<uint32_t>(height - (topCapInset + bottomCapInset));
+    uint32_t bottomHeight = static_cast<uint32_t>(bottomCapInset);
+
+    uint32_t topVerticalOffset = static_cast<uint32_t>(height - topCapInset);
+    uint32_t centerVerticalOffset = static_cast<uint32_t>(bottomCapInset);
+    uint32_t bottomVerticalOffset = static_cast<uint32_t>(0);
+
+    uint32_t leftHorizontalOffset = static_cast<uint32_t>(0);
+    uint32_t centerHorizontalOffset = static_cast<uint32_t>(leftCapInset);
+    uint32_t rightHorizontalOffset = static_cast<uint32_t>(width - rightCapInset);
+
+    switch (resizingMode) {
+        case xcassets::Resizing::Mode::ThreePartHorizontal:
+            return {
+                { leftHorizontalOffset,   0, leftWidth,   height },
+                { centerHorizontalOffset, 0, centerWidth, height },
+                { rightHorizontalOffset,  0, rightWidth,  height },
+            };
+        case xcassets::Resizing::Mode::ThreePartVertical:
+            return {
+                { 0, topVerticalOffset,    width, topHeight    },
+                { 0, centerVerticalOffset, width, centerHeight },
+                { 0, bottomVerticalOffset, width, bottomHeight },
+            };
+        case xcassets::Resizing::Mode::NinePart:
+            return {
+                { leftHorizontalOffset,   topVerticalOffset,    leftWidth,   topHeight    },
+                { centerHorizontalOffset, topVerticalOffset,    centerWidth, topHeight    },
+                { rightHorizontalOffset,  topVerticalOffset,    rightWidth,  topHeight    },
+                { leftHorizontalOffset,   centerVerticalOffset, leftWidth,   centerHeight },
+                { centerHorizontalOffset, centerVerticalOffset, centerWidth, centerHeight },
+                { rightHorizontalOffset,  centerVerticalOffset, rightWidth,  centerHeight },
+                { leftHorizontalOffset,   bottomVerticalOffset, leftWidth,   bottomHeight },
+                { centerHorizontalOffset, bottomVerticalOffset, centerWidth, bottomHeight },
+                { rightHorizontalOffset,  bottomVerticalOffset, rightWidth,  bottomHeight },
+            };
+        default: abort();
+    }
+}
+
+bool CompileActionImageSet::
+Compile(
+    std::shared_ptr<xcassets::Asset::ImageSet> const &imageSet,
+    libutil::Filesystem *filesystem,
+    Options const &options,
+    CompileOutput *compileOutput,
+    Result *result)
+{
+    bool success = true;
+
+    if (imageSet->images()) {
+        for (xcassets::Asset::ImageSet::Image const &image : *imageSet->images()) {
+            if (!CompileAsset(imageSet, image, filesystem, options, compileOutput, result)) {
+                success = false;
+            }
+        }
+    }
+
+    return success;
+}
+
+static uint16_t
 GenerateIdentifier(void) {
     static uint16_t last = 0;
     last = last + 1;
     return last;
 }
 
-static uint16_t
-assetIdiomToRenditionIdiom(xcassets::Slot::Idiom assetIdiom)
-{
-    uint16_t renditionIdiom = car_attribute_identifier_idiom_value_universal;
-    switch(assetIdiom) {
-        case xcassets::Slot::Idiom::Universal:
-            renditionIdiom = car_attribute_identifier_idiom_value_universal;
-            break;
-        case xcassets::Slot::Idiom::Phone:
-            renditionIdiom = car_attribute_identifier_idiom_value_phone;
-            break;
-        case xcassets::Slot::Idiom::Pad:
-            renditionIdiom = car_attribute_identifier_idiom_value_pad;
-            break;
-        case xcassets::Slot::Idiom::Desktop:
-            // TODO: desktop has no idiom value
-            break;
-        case xcassets::Slot::Idiom::TV:
-            renditionIdiom = car_attribute_identifier_idiom_value_tv;
-            break;
-        case xcassets::Slot::Idiom::Watch:
-            renditionIdiom = car_attribute_identifier_idiom_value_watch;
-            break;
-        case xcassets::Slot::Idiom::Car:
-            renditionIdiom = car_attribute_identifier_idiom_value_car;
-            break;
-    }
-    return renditionIdiom;
-}
-
-bool
+bool CompileActionImageSet::
 CompileAsset(
+    std::shared_ptr<xcassets::Asset::ImageSet> const &imageSet,
     xcassets::Asset::ImageSet::Image const &image,
-    std::shared_ptr<xcassets::Asset::Asset> const &parent,
     libutil::Filesystem *filesystem,
     Options const &options,
     CompileOutput *compileOutput,
-    Result *result
-    )
+    Result *result)
 {
     static std::map<std::string, uint16_t> idMap = {};
 
-    /* Skip any entry that is not attached to a file, or is explicitly unassigned */
+    /* Skip any entry that is not attached to a file, or is explicitly unassigned. */
     if (!image.fileName() || image.unassigned()) {
         return true;
     }
 
-    std::string filename = FSUtil::ResolveRelativePath(*image.fileName(), parent->path());
-
-    /* An image without an idiom is considered unassigned */
+    /* An image without an idiom is considered unassigned. */
     if (!image.idiom()) {
         return false;
     }
 
-    std::string name = parent->name().string();
+    std::string filename = FSUtil::ResolveRelativePath(*image.fileName(), imageSet->path());
 
-    /* scale defaults to 0 / all */
-    double scale = image.scale()->value();
+    std::string name = imageSet->name().string();
 
-    // TODO: We should filter by target-device / device-model / os-version
-    uint16_t idiom = assetIdiomToRenditionIdiom(*image.idiom());
+    /* The default (0) is any scale. */
+    double scale = 0;
+    if (image.scale()) {
+        scale = image.scale()->value();
+    }
 
-    std::vector<unsigned char> pixels;
+    // TODO: filter by target-device / device-model / os-version
+    uint16_t idiom = IdiomAttributeForIdiom(*image.idiom());
+
+    std::vector<uint8_t> pixels;
     size_t width = 0;
     size_t height = 0;
     size_t channels = 0;
@@ -297,41 +405,38 @@ CompileAsset(
 
     if (FSUtil::IsFileExtension(filename, "png", true)) {
         std::vector<uint8_t> contents;
-        if (!filesystem || !filesystem->read(&contents, filename)) {
+        if (!filesystem->read(&contents, filename)) {
             result->normal(
                 Result::Severity::Error,
-                "unable to open PNG file",
-                std::string(filename));
+                "unable to read PNG file",
+                filename);
             return false;
         }
-        if(!readPNGFile(contents, filename, pixels, &width, &height, &channels, result)) {
+
+        if (!ReadPNGFile(contents, filename, &pixels, &width, &height, &channels, result)) {
             return false;
         }
-        format = channels == 4 ?
-        car::Rendition::Data::Format::PremultipliedBGRA8 :
-        car::Rendition::Data::Format::PremultipliedGA8;
-    } else if (FSUtil::IsFileExtension(filename, "jpg", true) ||
-        FSUtil::IsFileExtension(filename, "jpeg", true)) {
-        std::ifstream inputFile(filename.c_str(), std::ios::binary);
-        if (inputFile.is_open()) {
-            inputFile.seekg(0, std::ios::end);
-            pixels.reserve(inputFile.tellg());
-            inputFile.seekg(0, std::ios::beg);
-            pixels.assign((std::istreambuf_iterator<char>(inputFile)),
-                          std::istreambuf_iterator<char>());
-            format = car::Rendition::Data::Format::JPEG;
+
+        if (channels == 4) {
+            format = car::Rendition::Data::Format::PremultipliedBGRA8;
         } else {
+            format = car::Rendition::Data::Format::PremultipliedGA8;
+        }
+    } else if (FSUtil::IsFileExtension(filename, "jpg", true) || FSUtil::IsFileExtension(filename, "jpeg", true)) {
+        if (!filesystem->read(&pixels, filename)) {
             result->normal(
                 Result::Severity::Error,
-                "unable to open JPG file",
-                std::string(filename));
+                "unable to read JPEG file",
+                filename);
             return false;
         }
+
+        format = car::Rendition::Data::Format::JPEG;
     } else {
         result->normal(
             Result::Severity::Error,
-            "unable to load file",
-            std::string(filename));
+            "unknown file type",
+            filename);
         return false;
     }
 
@@ -347,149 +452,48 @@ CompileAsset(
     }
     if (createFacet) {
         car::AttributeList attributes = car::AttributeList({
-            { car_attribute_identifier_identifier, facetIdentifier }
+            { car_attribute_identifier_identifier, facetIdentifier },
         });
 
         car::Facet facet = car::Facet::Create(name, attributes);
         compileOutput->car()->addFacet(facet);
     }
 
+    /*
+     * Create rendition for the image.
+     */
     car::AttributeList attributes = car::AttributeList({
         { car_attribute_identifier_idiom, idiom },
-        { car_attribute_identifier_scale, (int)scale },
+        { car_attribute_identifier_scale, static_cast<int>(scale) },
         { car_attribute_identifier_identifier, facetIdentifier },
     });
 
     auto data = ext::optional<car::Rendition::Data>(car::Rendition::Data(std::move(pixels), format));
 
     car::Rendition rendition = car::Rendition::Create(attributes, std::move(data));
-
     rendition.width() = width;
     rendition.height() = height;
     rendition.scale() = scale;
     rendition.fileName() = *image.fileName();
 
     if (image.resizing()) {
-        auto resizing = *image.resizing();
-        double topCapInset = 0;
-        double leftCapInset = 0;
-        double bottomCapInset = 0;
-        double rightCapInset = 0;
-        if (resizing.capInsets()) {
-            auto capInsets = *resizing.capInsets();
-            topCapInset = *capInsets.top();
-            leftCapInset = *capInsets.left();
-            bottomCapInset = *capInsets.bottom();
-            rightCapInset = *capInsets.right();
-        }
+        xcassets::Resizing const &resizing = *image.resizing();
 
-        xcassets::Resizing::Center::Mode centreMode = xcassets::Resizing::Center::Mode::Tile;
+        xcassets::Resizing::Center::Mode centerMode = xcassets::Resizing::Center::Mode::Tile;
         if (resizing.center()) {
-            auto center = *resizing.center();
+            xcassets::Resizing::Center const &center = *resizing.center();
             if (center.mode()) {
-                centreMode = *center.mode();
+                centerMode = *center.mode();
             }
 
             /* TODO: center size is currently ingnored */
         }
 
-        std::vector<car::Rendition::Slice> slices;
-        enum car_rendition_value_layout layout = car_rendition_value_layout_one_part_fixed_size;
-        switch(*resizing.mode()) {
-            case xcassets::Resizing::Mode::ThreePartHorizontal:
-                {
-                    slices.push_back({0, 0, (uint32_t)leftCapInset, (uint32_t)height});
-                    slices.push_back({(uint32_t)leftCapInset, 0, (uint32_t)(width - (leftCapInset + rightCapInset)), (uint32_t)height});
-                    slices.push_back({(uint32_t)(width - rightCapInset), 0, (uint32_t)rightCapInset, (uint32_t)height});
-
-                    switch(centreMode) {
-                        case xcassets::Resizing::Center::Mode::Tile:
-                            layout = car_rendition_value_layout_three_part_horizontal_tile;
-                            break;
-                        case xcassets::Resizing::Center::Mode::Stretch:
-                            layout = car_rendition_value_layout_three_part_horizontal_scale;
-                            break;
-                        default:
-                            layout = car_rendition_value_layout_three_part_horizontal_tile;
-                    }
-                }
-                break;
-
-            case xcassets::Resizing::Mode::ThreePartVertical:
-                {
-                    slices.push_back({0, (uint32_t)(height - topCapInset), (uint32_t)width, (uint32_t)topCapInset});
-                    slices.push_back({0, (uint32_t)bottomCapInset, (uint32_t)width, (uint32_t)(height - (topCapInset + bottomCapInset))});
-                    slices.push_back({0, 0, (uint32_t)width, (uint32_t)bottomCapInset});
-
-                    switch(centreMode) {
-                        case xcassets::Resizing::Center::Mode::Tile:
-                            layout = car_rendition_value_layout_three_part_vertical_tile;
-                            break;
-                        case xcassets::Resizing::Center::Mode::Stretch:
-                            layout = car_rendition_value_layout_three_part_vertical_scale;
-                            break;
-                        default:
-                            layout = car_rendition_value_layout_three_part_vertical_tile;
-                    }
-                }
-                break;
-
-            case xcassets::Resizing::Mode::NinePart:
-                {
-                    uint32_t centerWidth = width - (leftCapInset + rightCapInset);
-                    uint32_t centerHeight = height - (topCapInset + bottomCapInset);
-
-                    // each slice is the origin and size of a resizeable part of the image
-                    slices = std::vector<car::Rendition::Slice>(9);
-
-                    // first column
-                    for (auto i : {0,3,6}) {
-                        slices[i].x = 0;
-                        slices[i].width = leftCapInset;
-                    }
-                    // second column
-                    for (auto i : {1,4,7}) {
-                        slices[i].x = leftCapInset;
-                        slices[i].width = centerWidth;
-                    }
-                    // third column
-                    for (auto i : {2,5,8}) {
-                        slices[i].x = width - rightCapInset;
-                        slices[i].width = rightCapInset;
-                    }
-                    // first row
-                    for (auto i : {0,1,2}) {
-                        slices[i].y = height - topCapInset;
-                        slices[i].height = topCapInset;
-                    }
-                    // second row
-                    for (auto i : {3,4,5}) {
-                        slices[i].y = bottomCapInset;
-                        slices[i].height = centerHeight;
-                    }
-                    // third row
-                    for (auto i : {6,7,8}) {
-                        slices[i].y = 0;
-                        slices[i].height = bottomCapInset;
-                    }
-
-                    switch(centreMode) {
-                        case xcassets::Resizing::Center::Mode::Tile:
-                            layout = car_rendition_value_layout_nine_part_tile;
-                            break;
-                        case xcassets::Resizing::Center::Mode::Stretch:
-                            layout = car_rendition_value_layout_nine_part_scale;
-                            break;
-                        default:
-                            layout = car_rendition_value_layout_nine_part_tile;
-                    }
-                }
-                break;
-            default:
-                printf("Resizing:Mode:Unknown\n");
+        if (resizing.mode()) {
+            xcassets::Resizing::Mode resizingMode = *resizing.mode();
+            rendition.layout() = LayoutForResizingAndCenterMode(resizingMode, centerMode);
+            rendition.slices() = SlicesForResizingModeAndCapInsets(width, height, resizingMode, resizing.capInsets());
         }
-        rendition.slices() = slices;
-        rendition.layout() = layout;
     }
 
     compileOutput->car()->addRendition(std::move(rendition));


### PR DESCRIPTION
 - Refactor some logic out into separate functions.
 - Cleanup code style nits for consistency.
 - Use filesystem to read JPEG images as well as PNG.
 - Move image set compilation into namespace and class.