### PR TITLE
Additionally search `PATH` for tools in xcrun.

### DIFF
--- a/Libraries/libutil/Headers/libutil/FSUtil.h
+++ b/Libraries/libutil/Headers/libutil/FSUtil.h
@@ -61,7 +61,9 @@ public:
 public:
     static std::string FindFile(std::string const &name, std::vector<std::string> const &paths);
     static std::string FindExecutable(std::string const &name, std::vector<std::string> const &paths);
-    static std::string FindExecutable(std::string const &name);
+
+public:
+    static std::vector<std::string> GetExecutablePaths();
 };
 
 }

--- a/Libraries/libutil/Headers/libutil/Filesystem.h
+++ b/Libraries/libutil/Headers/libutil/Filesystem.h
@@ -120,9 +120,6 @@ public:
      * Finds an executable in the given directories.
      */
     ext::optional<std::string> findExecutable(std::string const &name, std::vector<std::string> const &paths) const;
-
-    // FIXME: Remove this and reference PATH explicitly.
-    ext::optional<std::string> findExecutable(std::string const &name) const;
 };
 
 }

--- a/Libraries/libutil/Sources/FSUtil.cpp
+++ b/Libraries/libutil/Sources/FSUtil.cpp
@@ -276,8 +276,8 @@ EnumerateRecursive(std::string const &path, std::function <bool(std::string cons
     return true;
 }
 
-std::string FSUtil::
-FindExecutable(std::string const &name)
+std::vector<std::string> FSUtil::
+GetExecutablePaths()
 {
     std::vector<std::string>        vpaths;
     std::unordered_set<std::string> seen;
@@ -285,14 +285,15 @@ FindExecutable(std::string const &name)
     std::istringstream              is(::getenv("PATH"));
 
     while (std::getline(is, path, ':')) {
-        if (seen.find(path) != seen.end())
+        if (seen.find(path) != seen.end()) {
             continue;
+        }
 
         vpaths.push_back(path);
         seen.insert(path);
     }
 
-    return FindExecutable(name, vpaths);
+    return vpaths;
 }
 
 std::string FSUtil::

--- a/Libraries/libutil/Sources/Filesystem.cpp
+++ b/Libraries/libutil/Sources/Filesystem.cpp
@@ -69,22 +69,3 @@ findExecutable(std::string const &name, std::vector<std::string> const &paths) c
     return ext::nullopt;
 }
 
-ext::optional<std::string> Filesystem::
-findExecutable(std::string const &name) const
-{
-    std::vector<std::string>        vpaths;
-    std::unordered_set<std::string> seen;
-    std::string                     path;
-    std::istringstream              is(::getenv("PATH"));
-
-    while (std::getline(is, path, ':')) {
-        if (seen.find(path) != seen.end()) {
-            continue;
-        }
-
-        vpaths.push_back(path);
-        seen.insert(path);
-    }
-
-    return findExecutable(name, vpaths);
-}

--- a/Libraries/xcexecution/Sources/NinjaExecutor.cpp
+++ b/Libraries/xcexecution/Sources/NinjaExecutor.cpp
@@ -354,12 +354,12 @@ build(
         /*
          * Find the path to the Ninja executable to use.
          */
-        ext::optional<std::string> executable = filesystem->findExecutable("ninja");
+        ext::optional<std::string> executable = filesystem->findExecutable("ninja", FSUtil::GetExecutablePaths());
         if (!executable) {
             /*
              * Couldn't find standard Ninja, try with llbuild.
              */
-            executable = filesystem->findExecutable("llbuild");
+            executable = filesystem->findExecutable("llbuild", FSUtil::GetExecutablePaths());
 
             /*
              * If neither Ninja or llbuild are available, can't start the build.

--- a/Libraries/xcsdk/Tools/xcrun.cpp
+++ b/Libraries/xcsdk/Tools/xcrun.cpp
@@ -13,6 +13,7 @@
 #include <xcsdk/SDK/Toolchain.h>
 #include <libutil/DefaultFilesystem.h>
 #include <libutil/Filesystem.h>
+#include <libutil/FSUtil.h>
 #include <libutil/Options.h>
 #include <libutil/Subprocess.h>
 #include <libutil/SysUtil.h>
@@ -20,6 +21,7 @@
 
 using libutil::DefaultFilesystem;
 using libutil::Filesystem;
+using libutil::FSUtil;
 using libutil::SysUtil;
 using libutil::Subprocess;
 
@@ -391,9 +393,15 @@ main(int argc, char **argv)
         }
 
         /*
-         * Find the tool to execute in the SDK or toolchains.
+         * Collect search paths for the tool. Can be in toolchains, target, developer root, or default paths.
          */
         std::vector<std::string> executablePaths = target->executablePaths(toolchains);
+        std::vector<std::string> defaultExecutablePaths = FSUtil::GetExecutablePaths();
+        executablePaths.insert(executablePaths.end(), defaultExecutablePaths.begin(), defaultExecutablePaths.end());
+
+        /*
+         * Find the tool to execute.
+         */
         ext::optional<std::string> executable = filesystem->findExecutable(options.tool(), executablePaths);
         if (!executable) {
             fprintf(stderr, "error: tool '%s' not found\n", options.tool().c_str());


### PR DESCRIPTION
In addition to the SDK, toolchains, and developer root. Also, refactor
executable search paths to require explicitly searching `PATH` rather
than treating it as a default.