### PR TITLE
Use optionals in parsing command line arguments.

### DIFF
--- a/Libraries/acdriver/Headers/acdriver/Options.h
+++ b/Libraries/acdriver/Headers/acdriver/Options.h
@@ -22,40 +22,40 @@ namespace acdriver {
  */
 class Options {
 private:
-    bool        _version;
-    bool        _printContents;
-    std::vector<std::string> _inputs;
+    ext::optional<bool>        _version;
+    ext::optional<bool>        _printContents;
+    std::vector<std::string>   _inputs;
 
 private:
-    std::string _outputFormat;
-    bool        _warnings;
-    bool        _errors;
-    bool        _notices;
+    ext::optional<std::string> _outputFormat;
+    ext::optional<bool>        _warnings;
+    ext::optional<bool>        _errors;
+    ext::optional<bool>        _notices;
 
 private:
-    std::string _compile;
-    std::string _exportDependencyInfo;
+    ext::optional<std::string> _compile;
+    ext::optional<std::string> _exportDependencyInfo;
 
 private:
-    std::string _optimization;
-    bool        _compressPNGs;
+    ext::optional<std::string> _optimization;
+    ext::optional<bool>        _compressPNGs;
 
 private:
-    std::string _platform;
-    std::string _minimumDeploymentTarget;
-    std::vector<std::string> _targetDevice;
+    ext::optional<std::string> _platform;
+    ext::optional<std::string> _minimumDeploymentTarget;
+    std::vector<std::string>   _targetDevice;
 
 private:
-    std::string _outputPartialInfoPlist;
-    std::string _appIcon;
-    std::string _launchImage;
+    ext::optional<std::string> _outputPartialInfoPlist;
+    ext::optional<std::string> _appIcon;
+    ext::optional<std::string> _launchImage;
 
 private:
-    bool        _enableOnDemandResources;
-    bool        _enableIncrementalDistill;
-    std::string _targetName;
-    std::string _filterForDeviceModel;
-    std::string _filterForDeviceOsVersion;
+    ext::optional<bool>        _enableOnDemandResources;
+    ext::optional<bool>        _enableIncrementalDistill;
+    ext::optional<std::string> _targetName;
+    ext::optional<std::string> _filterForDeviceModel;
+    ext::optional<std::string> _filterForDeviceOsVersion;
 
 public:
     Options();
@@ -63,60 +63,60 @@ public:
 
 public:
     bool version() const
-    { return _version; }
+    { return _version.value_or(false); }
     bool printContents() const
-    { return _printContents; }
-    std::string const &compile() const
+    { return _printContents.value_or(false); }
+    ext::optional<std::string> const &compile() const
     { return _compile; }
 
 public:
-    std::string const &outputFormat() const
+    ext::optional<std::string> const &outputFormat() const
     { return _outputFormat; }
     bool warnings() const
-    { return _warnings; }
+    { return _warnings.value_or(false); }
     bool errors() const
-    { return _errors; }
+    { return _errors.value_or(false); }
     bool notices() const
-    { return _notices; }
+    { return _notices.value_or(false); }
 
 public:
-    std::string const &exportDependencyInfo() const
+    ext::optional<std::string> const &exportDependencyInfo() const
     { return _exportDependencyInfo; }
     std::vector<std::string> const &inputs() const
     { return _inputs; }
 
 public:
-    std::string const &optimization() const
+    ext::optional<std::string> const &optimization() const
     { return _optimization; }
     bool compressPNGs() const
-    { return _compressPNGs; }
+    { return _compressPNGs.value_or(false); }
 
 public:
-    std::string const &platform() const
+    ext::optional<std::string> const &platform() const
     { return _platform; }
-    std::string const &minimumDeploymentTarget() const
+    ext::optional<std::string> const &minimumDeploymentTarget() const
     { return _minimumDeploymentTarget; }
     std::vector<std::string> const &targetDevice() const
     { return _targetDevice; }
 
 public:
-    std::string const &outputPartialInfoPlist() const
+    ext::optional<std::string> const &outputPartialInfoPlist() const
     { return _outputPartialInfoPlist; }
-    std::string const &appIcon() const
+    ext::optional<std::string> const &appIcon() const
     { return _appIcon; }
-    std::string const &launchImage() const
+    ext::optional<std::string> const &launchImage() const
     { return _launchImage; }
 
 public:
     bool enableOnDemandResources() const
-    { return _enableOnDemandResources; }
+    { return _enableOnDemandResources.value_or(false); }
     bool enableIncrementalDistill() const
-    { return _enableIncrementalDistill; }
-    std::string const &targetName() const
+    { return _enableIncrementalDistill.value_or(false); }
+    ext::optional<std::string> const &targetName() const
     { return _targetName; }
-    std::string const &filterForDeviceModel() const
+    ext::optional<std::string> const &filterForDeviceModel() const
     { return _filterForDeviceModel; }
-    std::string const &filterForDeviceOsVersion() const
+    ext::optional<std::string> const &filterForDeviceOsVersion() const
     { return _filterForDeviceOsVersion; }
 
 private:

--- a/Libraries/acdriver/Sources/CompileAction.cpp
+++ b/Libraries/acdriver/Sources/CompileAction.cpp
@@ -205,9 +205,9 @@ CompileAsset(
 }
 
 static ext::optional<CompileOutput::Format>
-DetermineOutputFormat(std::string const &minimumDeploymentTarget)
+DetermineOutputFormat(ext::optional<std::string> const &minimumDeploymentTarget)
 {
-    if (!minimumDeploymentTarget.empty()) {
+    if (minimumDeploymentTarget) {
         // TODO: if < 7, use Folder output format
     }
 
@@ -226,7 +226,7 @@ run(Filesystem *filesystem, Options const &options, Output *output, Result *resu
         return;
     }
 
-    CompileOutput compileOutput = CompileOutput(options.compile(), *outputFormat);
+    CompileOutput compileOutput = CompileOutput(*options.compile(), *outputFormat);
 
     /*
      * If necssary, create output archive to write into.
@@ -274,27 +274,27 @@ run(Filesystem *filesystem, Options const &options, Output *output, Result *resu
         // TODO: use these options:
         /*
         if (arg == "--optimization") {
-            return libutil::Options::NextString(&_optimization, args, it);
+            return libutil::Options::Next<std::string>(&_optimization, args, it);
         } else if (arg == "--compress-pngs") {
-            return libutil::Options::MarkBool(&_compressPNGs, arg);
+            return libutil::Options::Current<bool>(&_compressPNGs, arg);
         } else if (arg == "--platform") {
-            return libutil::Options::NextString(&_platform, args, it);
+            return libutil::Options::Next<std::string>(&_platform, args, it);
         } else if (arg == "--target-device") {
-            return libutil::Options::NextString(&_targetDevice, args, it);
+            return libutil::Options::Next<std::string>(&_targetDevice, args, it);
         } else if (arg == "--app-icon") {
-            return libutil::Options::NextString(&_appIcon, args, it);
+            return libutil::Options::Next<std::string>(&_appIcon, args, it);
         } else if (arg == "--launch-image") {
-            return libutil::Options::NextString(&_launchImage, args, it);
+            return libutil::Options::Next<std::string>(&_launchImage, args, it);
         } else if (arg == "--enable-on-demand-resources") {
-            return libutil::Options::MarkBool(&_enableOnDemandResources, arg);
+            return libutil::Options::Current<bool>(&_enableOnDemandResources, arg);
         } else if (arg == "--enable-incremental-distill") {
-            return libutil::Options::MarkBool(&_enableIncrementalDistill, arg);
+            return libutil::Options::Current<bool>(&_enableIncrementalDistill, arg);
         } else if (arg == "--target-name") {
-            return libutil::Options::NextString(&_targetName, args, it);
+            return libutil::Options::Next<std::string>(&_targetName, args, it);
         } else if (arg == "--filter-for-device-model") {
-            return libutil::Options::NextString(&_filterForDeviceModel, args, it);
+            return libutil::Options::Next<std::string>(&_filterForDeviceModel, args, it);
         } else if (arg == "--filter-for-device-os-version") {
-            return libutil::Options::NextString(&_filterForDeviceOsVersion, args, it);
+            return libutil::Options::Next<std::string>(&_filterForDeviceOsVersion, args, it);
         }
         */
     }
@@ -302,9 +302,7 @@ run(Filesystem *filesystem, Options const &options, Output *output, Result *resu
     /*
      * Write out the output.
      */
-    ext::optional<std::string> partialInfoPlist = (!options.outputPartialInfoPlist().empty() ? ext::optional<std::string>(options.outputPartialInfoPlist()) : ext::nullopt);
-    ext::optional<std::string> dependencyInfo = (!options.exportDependencyInfo().empty() ? ext::optional<std::string>(options.exportDependencyInfo()) : ext::nullopt);
-    if (!compileOutput.write(filesystem, partialInfoPlist, dependencyInfo, result)) {
+    if (!compileOutput.write(filesystem, options.outputPartialInfoPlist(), options.exportDependencyInfo(), result)) {
         /* Error already reported. */
     }
 }

--- a/Libraries/acdriver/Sources/Driver.cpp
+++ b/Libraries/acdriver/Sources/Driver.cpp
@@ -52,7 +52,7 @@ RunInternal(Filesystem *filesystem, Options const &options, Output *output, Resu
         contents.run(filesystem, options, output, result);
     }
 
-    if (!options.compile().empty()) {
+    if (options.compile()) {
         CompileAction compile;
         compile.run(filesystem, options, output, result);
     }
@@ -61,11 +61,11 @@ RunInternal(Filesystem *filesystem, Options const &options, Output *output, Resu
 static Output::Format
 OptionsOutputFormat(Options const &options, Result *result)
 {
-    if (options.outputFormat().empty() || options.outputFormat() == "xml1") {
+    if (!options.outputFormat() || *options.outputFormat() == "xml1") {
         return Output::Format::XML;
-    } else if (options.outputFormat() == "binary1") {
+    } else if (*options.outputFormat() == "binary1") {
         return Output::Format::Binary;
-    } else if (options.outputFormat() == "human-readable-text") {
+    } else if (*options.outputFormat() == "human-readable-text") {
         return Output::Format::Text;
     } else {
         result->normal(Result::Severity::Error, "unknown output format");

--- a/Libraries/acdriver/Sources/Options.cpp
+++ b/Libraries/acdriver/Sources/Options.cpp
@@ -12,15 +12,7 @@
 using acdriver::Options;
 
 Options::
-Options() :
-    _version(false),
-    _printContents(false),
-    _warnings(false),
-    _errors(false),
-    _notices(false),
-    _compressPNGs(false),
-    _enableOnDemandResources(false),
-    _enableIncrementalDistill(false)
+Options()
 {
 }
 
@@ -35,55 +27,49 @@ parseArgument(std::vector<std::string> const &args, std::vector<std::string>::co
     std::string const &arg = **it;
 
     if (arg == "--version") {
-        return libutil::Options::MarkBool(&_version, arg);
+        return libutil::Options::Current<bool>(&_version, arg);
     } else if (arg == "--print-contents") {
-        return libutil::Options::MarkBool(&_printContents, arg);
+        return libutil::Options::Current<bool>(&_printContents, arg);
     } else if (arg == "--compile") {
-        return libutil::Options::NextString(&_compile, args, it);
+        return libutil::Options::Next<std::string>(&_compile, args, it);
     } else if (arg == "--output-format") {
-        return libutil::Options::NextString(&_outputFormat, args, it);
+        return libutil::Options::Next<std::string>(&_outputFormat, args, it);
     } else if (arg == "--warnings") {
-        return libutil::Options::MarkBool(&_warnings, arg);
+        return libutil::Options::Current<bool>(&_warnings, arg);
     } else if (arg == "--errors") {
-        return libutil::Options::MarkBool(&_errors, arg);
+        return libutil::Options::Current<bool>(&_errors, arg);
     } else if (arg == "--notices") {
-        return libutil::Options::MarkBool(&_notices, arg);
+        return libutil::Options::Current<bool>(&_notices, arg);
     } else if (arg == "--export-dependency-info") {
-        return libutil::Options::NextString(&_exportDependencyInfo, args, it);
+        return libutil::Options::Next<std::string>(&_exportDependencyInfo, args, it);
     } else if (arg == "--optimization") {
-        return libutil::Options::NextString(&_optimization, args, it);
+        return libutil::Options::Next<std::string>(&_optimization, args, it);
     } else if (arg == "--compress-pngs") {
-        return libutil::Options::MarkBool(&_compressPNGs, arg);
+        return libutil::Options::Current<bool>(&_compressPNGs, arg);
     } else if (arg == "--platform") {
-        return libutil::Options::NextString(&_platform, args, it);
+        return libutil::Options::Next<std::string>(&_platform, args, it);
     } else if (arg == "--minimum-deployment-target") {
-        return libutil::Options::NextString(&_minimumDeploymentTarget, args, it);
+        return libutil::Options::Next<std::string>(&_minimumDeploymentTarget, args, it);
     } else if (arg == "--target-device") {
-        std::string targetDevice;
-        auto result = libutil::Options::NextString(&targetDevice, args, it);
-        if (result.first) {
-            _targetDevice.push_back(targetDevice);
-        }
-        return result;
+        return libutil::Options::AppendNext<std::string>(&_targetDevice, args, it);
     } else if (arg == "--output-partial-info-plist") {
-        return libutil::Options::NextString(&_outputPartialInfoPlist, args, it);
+        return libutil::Options::Next<std::string>(&_outputPartialInfoPlist, args, it);
     } else if (arg == "--app-icon") {
-        return libutil::Options::NextString(&_appIcon, args, it);
+        return libutil::Options::Next<std::string>(&_appIcon, args, it);
     } else if (arg == "--launch-image") {
-        return libutil::Options::NextString(&_launchImage, args, it);
+        return libutil::Options::Next<std::string>(&_launchImage, args, it);
     } else if (arg == "--enable-on-demand-resources") {
-        return libutil::Options::NextBool(&_enableOnDemandResources, args, it, true);
+        return libutil::Options::Next<bool>(&_enableOnDemandResources, args, it, true);
     } else if (arg == "--enable-incremental-distill") {
-        return libutil::Options::MarkBool(&_enableIncrementalDistill, arg);
+        return libutil::Options::Current<bool>(&_enableIncrementalDistill, arg);
     } else if (arg == "--target-name") {
-        return libutil::Options::NextString(&_targetName, args, it);
+        return libutil::Options::Next<std::string>(&_targetName, args, it);
     } else if (arg == "--filter-for-device-model") {
-        return libutil::Options::NextString(&_filterForDeviceModel, args, it);
+        return libutil::Options::Next<std::string>(&_filterForDeviceModel, args, it);
     } else if (arg == "--filter-for-device-os-version") {
-        return libutil::Options::NextString(&_filterForDeviceOsVersion, args, it);
+        return libutil::Options::Next<std::string>(&_filterForDeviceOsVersion, args, it);
     } else if (!arg.empty() && arg[0] != '-') {
-        _inputs.push_back(arg);
-        return std::make_pair(true, std::string());
+        return libutil::Options::AppendCurrent<std::string>(&_inputs, arg);
     } else {
         return std::make_pair(false, "unknown argument " + arg);
     }

--- a/Libraries/builtin/Headers/builtin/copy/Options.h
+++ b/Libraries/builtin/Headers/builtin/copy/Options.h
@@ -28,21 +28,21 @@ public:
     };
 
 private:
-    bool                     _verbose;
-    bool                     _preserveHFSData;
+    ext::optional<bool>             _verbose;
+    ext::optional<bool>             _preserveHFSData;
 
 private:
-    std::vector<std::string> _inputs;
-    bool                     _ignoreMissingInputs;
-    bool                     _resolveSrcSymlinks;
-    std::string              _output;
-    std::vector<std::string> _excludes;
+    std::vector<std::string>        _inputs;
+    ext::optional<bool>             _ignoreMissingInputs;
+    ext::optional<bool>             _resolveSrcSymlinks;
+    ext::optional<std::string>      _output;
+    std::vector<std::string>        _excludes;
 
 private:
-    bool                     _stripDebugSymbols;
-    std::string              _stripTool;
-    BitcodeStripMode         _bitcodeStrip;
-    std::string              _bitcodeStripTool;
+    ext::optional<bool>             _stripDebugSymbols;
+    ext::optional<std::string>      _stripTool;
+    ext::optional<BitcodeStripMode> _bitcodeStrip;
+    ext::optional<std::string>      _bitcodeStripTool;
 
 public:
     Options();
@@ -50,30 +50,30 @@ public:
 
 public:
     bool verbose() const
-    { return _verbose; }
+    { return _verbose.value_or(false); }
     bool preserveHFSData() const
-    { return _preserveHFSData; }
+    { return _preserveHFSData.value_or(false); }
 
 public:
     std::vector<std::string> const &inputs() const
     { return _inputs; }
     bool ignoreMissingInputs() const
-    { return _ignoreMissingInputs; }
+    { return _ignoreMissingInputs.value_or(false); }
     bool resolveSrcSymlinks() const
-    { return _resolveSrcSymlinks; }
-    std::string const &output() const
+    { return _resolveSrcSymlinks.value_or(false); }
+    ext::optional<std::string> const &output() const
     { return _output; }
     std::vector<std::string> const &excludes() const
     { return _excludes; }
 
 public:
     bool stripDebugSymbols() const
-    { return _stripDebugSymbols; }
-    std::string const &stripTool() const
+    { return _stripDebugSymbols.value_or(false); }
+    ext::optional<std::string> const &stripTool() const
     { return _stripTool; }
-    BitcodeStripMode bitcodeStrip() const
+    ext::optional<BitcodeStripMode> bitcodeStrip() const
     { return _bitcodeStrip; }
-    std::string const &bitcodeStripTool() const
+    ext::optional<std::string> const &bitcodeStripTool() const
     { return _bitcodeStripTool; }
 
 private:

--- a/Libraries/builtin/Headers/builtin/copyPlist/Options.h
+++ b/Libraries/builtin/Headers/builtin/copyPlist/Options.h
@@ -21,17 +21,17 @@ namespace copyPlist {
 
 class Options {
 private:
-    std::vector<std::string> _inputs;
-    std::string              _outputDirectory;
+    std::vector<std::string>   _inputs;
+    ext::optional<std::string> _outputDirectory;
 
 public:
-    bool                     _validate;
+    ext::optional<bool>        _validate;
 
 public:
-    std::string              _convertFormat;
+    ext::optional<std::string> _convertFormat;
 
 public:
-    bool                     _separator;
+    bool                       _separator;
 
 public:
     Options();
@@ -40,15 +40,15 @@ public:
 public:
     std::vector<std::string> const &inputs() const
     { return _inputs; }
-    std::string const &outputDirectory() const
+    ext::optional<std::string> const &outputDirectory() const
     { return _outputDirectory; }
 
 public:
     bool validate() const
-    { return _validate; }
+    { return _validate.value_or(false); }
 
 public:
-    std::string const &convertFormat() const
+    ext::optional<std::string> const &convertFormat() const
     { return _convertFormat; }
 
 private:

--- a/Libraries/builtin/Headers/builtin/copyStrings/Options.h
+++ b/Libraries/builtin/Headers/builtin/copyStrings/Options.h
@@ -21,18 +21,18 @@ namespace copyStrings {
 
 class Options {
 private:
-    std::vector<std::string> _inputs;
-    std::string              _outputDirectory;
+    std::vector<std::string>   _inputs;
+    ext::optional<std::string> _outputDirectory;
 
 public:
-    bool                     _validate;
+    ext::optional<bool>        _validate;
 
 public:
-    std::string              _inputEncoding;
-    std::string              _outputEncoding;
+    ext::optional<std::string> _inputEncoding;
+    ext::optional<std::string> _outputEncoding;
 
 public:
-    bool                     _separator;
+    bool                       _separator;
 
 public:
     Options();
@@ -41,17 +41,17 @@ public:
 public:
     std::vector<std::string> const &inputs() const
     { return _inputs; }
-    std::string const &outputDirectory() const
+    ext::optional<std::string> const &outputDirectory() const
     { return _outputDirectory; }
 
 public:
     bool validate() const
-    { return _validate; }
+    { return _validate.value_or(false); }
 
 public:
-    std::string const &inputEncoding() const
+    ext::optional<std::string> const &inputEncoding() const
     { return _inputEncoding; }
-    std::string const &outputEncoding() const
+    ext::optional<std::string> const &outputEncoding() const
     { return _outputEncoding; }
 
 private:

--- a/Libraries/builtin/Headers/builtin/copyTiff/Options.h
+++ b/Libraries/builtin/Headers/builtin/copyTiff/Options.h
@@ -21,17 +21,17 @@ namespace copyTiff {
 
 class Options {
 private:
-    std::vector<std::string> _inputs;
-    std::string              _outputDirectory;
+    std::vector<std::string>   _inputs;
+    ext::optional<std::string> _outputDirectory;
 
 public:
-    bool                     _validate;
+    ext::optional<bool>        _validate;
 
 public:
-    std::string              _compressionFormat;
+    ext::optional<std::string> _compressionFormat;
 
 public:
-    bool                     _separator;
+    bool                       _separator;
 
 public:
     Options();
@@ -40,15 +40,15 @@ public:
 public:
     std::vector<std::string> const &inputs() const
     { return _inputs; }
-    std::string const &outputDirectory() const
+    ext::optional<std::string> const &outputDirectory() const
     { return _outputDirectory; }
 
 public:
-    bool validate() const
+    ext::optional<bool> validate() const
     { return _validate; }
 
 public:
-    std::string const &compressionFormat() const
+    ext::optional<std::string> const &compressionFormat() const
     { return _compressionFormat; }
 
 private:

--- a/Libraries/builtin/Headers/builtin/embeddedBinaryValidationUtility/Options.h
+++ b/Libraries/builtin/Headers/builtin/embeddedBinaryValidationUtility/Options.h
@@ -21,20 +21,20 @@ namespace embeddedBinaryValidationUtility {
 
 class Options {
 private:
-    std::string _input;
-    std::string _signingCert;
-    std::string _infoPlistPath;
+    ext::optional<std::string> _input;
+    ext::optional<std::string> _signingCert;
+    ext::optional<std::string> _infoPlistPath;
 
 public:
     Options();
     ~Options();
 
 public:
-    std::string const &input() const
+    ext::optional<std::string> const &input() const
     { return _input; }
-    std::string const &signingCert() const
+    ext::optional<std::string> const &signingCert() const
     { return _signingCert; }
-    std::string const &inputPlistPath() const
+    ext::optional<std::string> const &inputPlistPath() const
     { return _infoPlistPath; }
 
 private:

--- a/Libraries/builtin/Headers/builtin/infoPlistUtility/Options.h
+++ b/Libraries/builtin/Headers/builtin/infoPlistUtility/Options.h
@@ -21,60 +21,60 @@ namespace infoPlistUtility {
 
 class Options {
 private:
-    std::string              _input;
-    std::vector<std::string> _additionalContentFiles;
-    std::string              _output;
+    ext::optional<std::string> _input;
+    std::vector<std::string>   _additionalContentFiles;
+    ext::optional<std::string> _output;
 
 private:
-    std::string              _format;
-    bool                     _expandBuildSettings;
+    ext::optional<std::string> _format;
+    ext::optional<bool>        _expandBuildSettings;
 
 private:
-    std::string              _platform;
-    std::vector<std::string> _requiredArchitectures;
+    ext::optional<std::string> _platform;
+    std::vector<std::string>   _requiredArchitectures;
 
 private:
-    std::string              _genPkgInfo;
-    std::string              _resourceRulesFile;
+    ext::optional<std::string> _genPkgInfo;
+    ext::optional<std::string> _resourceRulesFile;
 
 private:
-    std::string              _infoFileKeys;
-    std::string              _infoFileValues;
+    ext::optional<std::string> _infoFileKeys;
+    ext::optional<std::string> _infoFileValues;
 
 public:
     Options();
     ~Options();
 
 public:
-    std::string const &input() const
+    ext::optional<std::string> const &input() const
     { return _input; }
     std::vector<std::string> const &additionalContentFiles() const
     { return _additionalContentFiles; }
-    std::string const &output() const
+    ext::optional<std::string> const &output() const
     { return _output; }
 
 public:
-    std::string const &format() const
+    ext::optional<std::string> const &format() const
     { return _format; }
     bool expandBuildSettings() const
-    { return _expandBuildSettings; }
+    { return _expandBuildSettings.value_or(false); }
 
 public:
-    std::string const &platform() const
+    ext::optional<std::string> const &platform() const
     { return _platform; }
     std::vector<std::string> const &requiredArchitectures() const
     { return _requiredArchitectures; }
 
 public:
-    std::string const &genPkgInfo() const
+    ext::optional<std::string> const &genPkgInfo() const
     { return _genPkgInfo; }
-    std::string const &resourceRulesFile() const
+    ext::optional<std::string> const &resourceRulesFile() const
     { return _resourceRulesFile; }
 
 public:
-    std::string const &infoFileKeys() const
+    ext::optional<std::string> const &infoFileKeys() const
     { return _infoFileKeys; }
-    std::string const &infoFileValues() const
+    ext::optional<std::string> const &infoFileValues() const
     { return _infoFileValues; }
 
 private:

--- a/Libraries/builtin/Headers/builtin/lsRegisterURL/Options.h
+++ b/Libraries/builtin/Headers/builtin/lsRegisterURL/Options.h
@@ -21,14 +21,14 @@ namespace lsRegisterURL {
 
 class Options {
 private:
-    std::string _input;
+    ext::optional<std::string> _input;
 
 public:
     Options();
     ~Options();
 
 public:
-    std::string const &input() const
+    ext::optional<std::string> const &input() const
     { return _input; }
 
 private:

--- a/Libraries/builtin/Headers/builtin/productPackagingUtility/Options.h
+++ b/Libraries/builtin/Headers/builtin/productPackagingUtility/Options.h
@@ -21,35 +21,35 @@ namespace productPackagingUtility {
 
 class Options {
 private:
-    std::string _input;
-    std::string _output;
+    ext::optional<std::string> _input;
+    ext::optional<std::string> _output;
 
 private:
-    bool        _removeFile;
-    bool        _entitlements;
-    bool        _resourceRules;
+    ext::optional<bool>        _removeFile;
+    ext::optional<bool>        _entitlements;
+    ext::optional<bool>        _resourceRules;
 
 private:
-    std::string _format;
+    ext::optional<std::string> _format;
 
 public:
     Options();
     ~Options();
 
 public:
-    std::string const &input() const
+    ext::optional<std::string> const &input() const
     { return _input; }
-    std::string const &output() const
+    ext::optional<std::string> const &output() const
     { return _output; }
 
 private:
     bool removeFile() const
-    { return _removeFile; }
+    { return _removeFile.value_or(false); }
     bool entitlements() const
-    { return _entitlements; }
+    { return _entitlements.value_or(false); }
 
 public:
-    std::string const &format() const
+    ext::optional<std::string> const &format() const
     { return _format; }
 
 private:

--- a/Libraries/builtin/Headers/builtin/validationUtility/Options.h
+++ b/Libraries/builtin/Headers/builtin/validationUtility/Options.h
@@ -21,21 +21,21 @@ namespace validationUtility {
 
 class Options {
 private:
-    std::string _input;
-    std::string _infoPlistPath;
-    bool        _validateForStore;
+    ext::optional<std::string> _input;
+    ext::optional<std::string> _infoPlistPath;
+    ext::optional<bool>        _validateForStore;
 
 public:
     Options();
     ~Options();
 
 public:
-    std::string const &input() const
+    ext::optional<std::string> const &input() const
     { return _input; }
-    std::string const &infoPlistPath() const
+    ext::optional<std::string> const &infoPlistPath() const
     { return _infoPlistPath; }
     bool validateForStore() const
-    { return _validateForStore; }
+    { return _validateForStore.value_or(false); }
 
 private:
     friend class libutil::Options;

--- a/Libraries/builtin/Sources/copy/Driver.cpp
+++ b/Libraries/builtin/Sources/copy/Driver.cpp
@@ -62,6 +62,11 @@ CopyPath(Filesystem *filesystem, std::string const &inputPath, std::string const
 static int
 Run(Filesystem *filesystem, Options const &options, std::string const &workingDirectory)
 {
+    if (!options.output()) {
+        fprintf(stderr, "error: no output path provided\n");
+        return 1;
+    }
+
     if (options.stripDebugSymbols() || options.bitcodeStrip() != Options::BitcodeStripMode::None) {
         // TODO(grp): Implement strip support when copying.
 #if 0
@@ -73,7 +78,7 @@ Run(Filesystem *filesystem, Options const &options, std::string const &workingDi
         fprintf(stderr, "warning: preserve HFS data is not supported\n");
     }
 
-    std::string const &output = FSUtil::ResolveRelativePath(options.output(), workingDirectory);
+    std::string const &output = FSUtil::ResolveRelativePath(*options.output(), workingDirectory);
     auto excludes = std::unordered_set<std::string>(options.excludes().begin(), options.excludes().end());
 
     for (std::string input : options.inputs()) {

--- a/Libraries/builtin/Sources/copyPlist/Driver.cpp
+++ b/Libraries/builtin/Sources/copyPlist/Driver.cpp
@@ -49,7 +49,7 @@ run(std::vector<std::string> const &args, std::unordered_map<std::string, std::s
      * It's unclear if an output directory should be required, but require it for
      * now since the behavior without one is also unclear.
      */
-    if (options.outputDirectory().empty()) {
+    if (!options.outputDirectory()) {
         fprintf(stderr, "error: output directory not provided\n");
         return 1;
     }
@@ -66,21 +66,21 @@ run(std::vector<std::string> const &args, std::unordered_map<std::string, std::s
      * Determine the output format. Leave null for the same as input.
      */
     std::unique_ptr<plist::Format::Any> convertFormat = nullptr;
-    if (!options.convertFormat().empty()) {
-        if (options.convertFormat() == "binary1") {
+    if (options.convertFormat()) {
+        if (*options.convertFormat() == "binary1") {
             convertFormat = std::unique_ptr<plist::Format::Any>(new plist::Format::Any(plist::Format::Any::Create(
                 plist::Format::Binary::Create()
             )));
-        } else if (options.convertFormat() == "xml1") {
+        } else if (*options.convertFormat() == "xml1") {
             convertFormat = std::unique_ptr<plist::Format::Any>(new plist::Format::Any(plist::Format::Any::Create(
                 plist::Format::XML::Create(plist::Format::Encoding::UTF8)
             )));
-        } else if (options.convertFormat() == "ascii1" || options.convertFormat() == "openstep1") {
+        } else if (*options.convertFormat() == "ascii1" || *options.convertFormat() == "openstep1") {
             convertFormat = std::unique_ptr<plist::Format::Any>(new plist::Format::Any(plist::Format::Any::Create(
                 plist::Format::ASCII::Create(false, plist::Format::Encoding::UTF8)
             )));
         } else {
-            fprintf(stderr, "error: unknown output format %s\n", options.convertFormat().c_str());
+            fprintf(stderr, "error: unknown output format %s\n", options.convertFormat()->c_str());
             return 1;
         }
     }
@@ -132,7 +132,7 @@ run(std::vector<std::string> const &args, std::unordered_map<std::string, std::s
         }
 
         /* Output to the same name as the input, but in the output directory. */
-        std::string outputPath = FSUtil::ResolveRelativePath(options.outputDirectory(), workingDirectory) + "/" + FSUtil::GetBaseName(inputPath);
+        std::string outputPath = FSUtil::ResolveRelativePath(*options.outputDirectory(), workingDirectory) + "/" + FSUtil::GetBaseName(inputPath);
 
         /* Write out the output. */
         if (!filesystem->write(outputContents, outputPath)) {

--- a/Libraries/builtin/Sources/copyPlist/Options.cpp
+++ b/Libraries/builtin/Sources/copyPlist/Options.cpp
@@ -13,7 +13,6 @@ using builtin::copyPlist::Options;
 
 Options::
 Options() :
-    _validate (false),
     _separator(false)
 {
 }
@@ -30,19 +29,19 @@ parseArgument(std::vector<std::string> const &args, std::vector<std::string>::co
 
     if (!_separator) {
         if (arg == "--validate") {
-            return libutil::Options::MarkBool(&_validate, arg, it);
+            return libutil::Options::Current<bool>(&_validate, arg, it);
         } else if (arg == "--convert") {
-            return libutil::Options::NextString(&_convertFormat, args, it);
+            return libutil::Options::Next<std::string>(&_convertFormat, args, it);
         } else if (arg == "--outdir") {
-            return libutil::Options::NextString(&_outputDirectory, args, it);
+            return libutil::Options::Next<std::string>(&_outputDirectory, args, it);
         } else if (arg == "--") {
-            return libutil::Options::MarkBool(&_separator, arg, it);
+            _separator = true;
+            return std::make_pair(true, std::string());
         }
     }
 
     if (_separator || (!arg.empty() && arg[0] != '-')) {
-        _inputs.push_back(arg);
-        return std::make_pair(true, std::string());
+        return libutil::Options::AppendCurrent<std::string>(&_inputs, arg);
     } else {
         return std::make_pair(false, "unknown argument " + arg);
     }

--- a/Libraries/builtin/Sources/copyStrings/Driver.cpp
+++ b/Libraries/builtin/Sources/copyStrings/Driver.cpp
@@ -45,9 +45,7 @@ name()
 static bool
 ParseStringsEncoding(std::string const &string, plist::Format::Any *format)
 {
-    if (string.empty()) {
-        return true;
-    } else if (strcasecmp(string.c_str(), "binary") == 0) {
+    if (strcasecmp(string.c_str(), "binary") == 0) {
         *format = plist::Format::Any::Create(plist::Format::Binary::Create());
         return true;
     } else if (strcasecmp(string.c_str(), "utf-8") == 0) {
@@ -96,7 +94,7 @@ ValidateOptions(Options const &options)
      * It's unclear if an output directory should be required, but require it for
      * now since the behavior without one is also unclear.
      */
-    if (options.outputDirectory().empty()) {
+    if (!options.outputDirectory()) {
         fprintf(stderr, "error: output directory not provided\n");
         return false;
     }
@@ -133,8 +131,8 @@ run(std::vector<std::string> const &args, std::unordered_map<std::string, std::s
      * Determine output encoding. Default to UTF-16 since that's what strings files should be.
      */
     plist::Format::Any outputFormat = plist::Format::Any::Create(plist::Format::ASCII::Create(true, plist::Format::Encoding::UTF16LE));
-    if (!ParseStringsEncoding(options.outputEncoding(), &outputFormat)) {
-        fprintf(stderr, "error: invalid output encoding '%s'\n", options.outputEncoding().c_str());
+    if (options.outputEncoding() && !ParseStringsEncoding(*options.outputEncoding(), &outputFormat)) {
+        fprintf(stderr, "error: invalid output encoding '%s'\n", options.outputEncoding()->c_str());
         return -1;
     }
 
@@ -159,8 +157,8 @@ run(std::vector<std::string> const &args, std::unordered_map<std::string, std::s
 
         /* If no input format was specified, use the detected strings encoding. */
         plist::Format::Any resolvedInputFormat = *inputFormat;
-        if (!ParseStringsEncoding(options.inputEncoding(), &resolvedInputFormat)) {
-            fprintf(stderr, "error: invalid input encoding '%s'\n", options.inputEncoding().c_str());
+        if (options.inputEncoding() && !ParseStringsEncoding(*options.inputEncoding(), &resolvedInputFormat)) {
+            fprintf(stderr, "error: invalid input encoding '%s'\n", options.inputEncoding()->c_str());
             return -1;
         }
 
@@ -181,7 +179,7 @@ run(std::vector<std::string> const &args, std::unordered_map<std::string, std::s
         }
 
         /* Output to the same name as the input, but in the output directory. */
-        std::string outputPath = FSUtil::ResolveRelativePath(options.outputDirectory(), workingDirectory) + "/" + FSUtil::GetBaseName(inputPath);
+        std::string outputPath = FSUtil::ResolveRelativePath(*options.outputDirectory(), workingDirectory) + "/" + FSUtil::GetBaseName(inputPath);
 
         /* Write out the output. */
         auto serialize = plist::Format::Any::Serialize(deserialize.first.get(), outputFormat);

--- a/Libraries/builtin/Sources/copyStrings/Options.cpp
+++ b/Libraries/builtin/Sources/copyStrings/Options.cpp
@@ -13,7 +13,6 @@ using builtin::copyStrings::Options;
 
 Options::
 Options() :
-    _validate (false),
     _separator(false)
 {
 }
@@ -30,21 +29,21 @@ parseArgument(std::vector<std::string> const &args, std::vector<std::string>::co
 
     if (!_separator) {
         if (arg == "--validate") {
-            return libutil::Options::MarkBool(&_validate, arg, it);
+            return libutil::Options::Current<bool>(&_validate, arg, it);
         } else if (arg == "--inputencoding") {
-            return libutil::Options::NextString(&_inputEncoding, args, it);
+            return libutil::Options::Next<std::string>(&_inputEncoding, args, it);
         } else if (arg == "--outputencoding") {
-            return libutil::Options::NextString(&_outputEncoding, args, it);
+            return libutil::Options::Next<std::string>(&_outputEncoding, args, it);
         } else if (arg == "--outdir") {
-            return libutil::Options::NextString(&_outputDirectory, args, it);
+            return libutil::Options::Next<std::string>(&_outputDirectory, args, it);
         } else if (arg == "--") {
-            return libutil::Options::MarkBool(&_separator, arg, it);
+            _separator = true;
+            return std::make_pair(true, std::string());
         }
     }
 
     if (_separator || (!arg.empty() && arg[0] != '-')) {
-        _inputs.push_back(arg);
-        return std::make_pair(true, std::string());
+        return libutil::Options::AppendCurrent<std::string>(&_inputs, arg);
     } else {
         return std::make_pair(false, "unknown argument " + arg);
     }

--- a/Libraries/builtin/Sources/copyTiff/Options.cpp
+++ b/Libraries/builtin/Sources/copyTiff/Options.cpp
@@ -13,7 +13,6 @@ using builtin::copyTiff::Options;
 
 Options::
 Options() :
-    _validate (false),
     _separator(false)
 {
 }
@@ -30,19 +29,19 @@ parseArgument(std::vector<std::string> const &args, std::vector<std::string>::co
 
     if (!_separator) {
         if (arg == "--validate") {
-            return libutil::Options::MarkBool(&_validate, arg, it);
+            return libutil::Options::Current<bool>(&_validate, arg, it);
         } else if (arg == "--compression") {
-            return libutil::Options::NextString(&_compressionFormat, args, it);
+            return libutil::Options::Next<std::string>(&_compressionFormat, args, it);
         } else if (arg == "--outdir") {
-            return libutil::Options::NextString(&_outputDirectory, args, it);
+            return libutil::Options::Next<std::string>(&_outputDirectory, args, it);
         } else if (arg == "--") {
-            return libutil::Options::MarkBool(&_separator, arg, it);
+            _separator = true;
+            return std::make_pair(true, std::string());
         }
     }
 
     if (_separator || (!arg.empty() && arg[0] != '-')) {
-        _inputs.push_back(arg);
-        return std::make_pair(true, std::string());
+        return libutil::Options::AppendCurrent<std::string>(&_inputs, arg);
     } else {
         return std::make_pair(false, "unknown argument " + arg);
     }

--- a/Libraries/builtin/Sources/embeddedBinaryValidationUtility/Options.cpp
+++ b/Libraries/builtin/Sources/embeddedBinaryValidationUtility/Options.cpp
@@ -27,17 +27,11 @@ parseArgument(std::vector<std::string> const &args, std::vector<std::string>::co
     std::string const &arg = **it;
 
     if (arg == "-signing-cert") {
-        return libutil::Options::NextString(&_signingCert, args, it);
+        return libutil::Options::Next<std::string>(&_signingCert, args, it);
     } else if (arg == "-info-plist-path") {
-        return libutil::Options::NextString(&_infoPlistPath, args, it);
+        return libutil::Options::Next<std::string>(&_infoPlistPath, args, it);
     } else if (!arg.empty() && arg[0] != '-') {
-        if (_input.empty()) {
-            _input = arg;
-            return std::make_pair(true, std::string());
-        } else {
-            return std::make_pair(false, "multiple inputs");
-        }
-        return std::make_pair(true, std::string());
+        return libutil::Options::Current<std::string>(&_input, arg);
     } else {
         return std::make_pair(false, "unknown argument " + arg);
     }

--- a/Libraries/builtin/Sources/infoPlistUtility/Options.cpp
+++ b/Libraries/builtin/Sources/infoPlistUtility/Options.cpp
@@ -12,8 +12,7 @@
 using builtin::infoPlistUtility::Options;
 
 Options::
-Options() :
-    _expandBuildSettings(false)
+Options()
 {
 }
 
@@ -28,42 +27,27 @@ parseArgument(std::vector<std::string> const &args, std::vector<std::string>::co
     std::string const &arg = **it;
 
     if (arg == "-genpkginfo") {
-        return libutil::Options::NextString(&_genPkgInfo, args, it);
+        return libutil::Options::Next<std::string>(&_genPkgInfo, args, it);
     } else if (arg == "-resourcerulesfile") {
-        return libutil::Options::NextString(&_resourceRulesFile, args, it);
+        return libutil::Options::Next<std::string>(&_resourceRulesFile, args, it);
     } else if (arg == "-expandbuildsettings") {
-        return libutil::Options::MarkBool(&_expandBuildSettings, arg, it);
+        return libutil::Options::Current<bool>(&_expandBuildSettings, arg, it);
     } else if (arg == "-format") {
-        return libutil::Options::NextString(&_format, args, it);
+        return libutil::Options::Next<std::string>(&_format, args, it);
     } else if (arg == "-platform") {
-        return libutil::Options::NextString(&_platform, args, it);
+        return libutil::Options::Next<std::string>(&_platform, args, it);
     } else if (arg == "-requiredArchitecture") {
-        std::string architecture;
-        std::pair<bool, std::string> result = libutil::Options::NextString(&architecture, args, it);
-        if (result.first) {
-            _requiredArchitectures.push_back(architecture);
-        }
-        return result;
+        return libutil::Options::AppendNext<std::string>(&_requiredArchitectures, args, it);
     } else if (arg == "-additionalcontentfile") {
-        std::string additional;
-        std::pair<bool, std::string> result = libutil::Options::NextString(&additional, args, it);
-        if (result.first) {
-            _additionalContentFiles.push_back(additional);
-        }
-        return result;
+        return libutil::Options::AppendNext<std::string>(&_additionalContentFiles, args, it);
     } else if (arg == "-infofilekeys") {
-        return libutil::Options::NextString(&_infoFileKeys, args, it);
+        return libutil::Options::Next<std::string>(&_infoFileKeys, args, it);
     } else if (arg == "-infofilevalues") {
-        return libutil::Options::NextString(&_infoFileValues, args, it);
+        return libutil::Options::Next<std::string>(&_infoFileValues, args, it);
     } else if (arg == "-o") {
-        return libutil::Options::NextString(&_output, args, it);
+        return libutil::Options::Next<std::string>(&_output, args, it);
     } else if (!arg.empty() && arg[0] != '-') {
-        if (_input.empty()) {
-            _input = arg;
-            return std::make_pair(true, std::string());
-        } else {
-            return std::make_pair(false, "multiple inputs");
-        }
+        return libutil::Options::Current<std::string>(&_input, arg);
     } else {
         return std::make_pair(false, "unknown argument " + arg);
     }

--- a/Libraries/builtin/Sources/lsRegisterURL/Driver.cpp
+++ b/Libraries/builtin/Sources/lsRegisterURL/Driver.cpp
@@ -50,11 +50,16 @@ run(std::vector<std::string> const &args, std::unordered_map<std::string, std::s
         return 1;
     }
 
+    if (!options.input()) {
+        fprintf(stderr, "error: no input specified\n");
+        return 1;
+    }
+
 #if defined(__APPLE__) && TARGET_OS_MAC && !TARGET_OS_IPHONE
-    CFURLRef URL = CFURLCreateFromFileSystemRepresentation(kCFAllocatorDefault, reinterpret_cast<const UInt8 *>(options.input().c_str()), options.input().size(), false);
+    CFURLRef URL = CFURLCreateFromFileSystemRepresentation(kCFAllocatorDefault, reinterpret_cast<const UInt8 *>(options.input()->c_str()), options.input()->size(), false);
     if (URL == NULL) {
         fprintf(stderr, "error: failed to create URL\n");
-        return -1;
+        return 1;
     }
 
     OSStatus status = LSRegisterURL(URL, true);

--- a/Libraries/builtin/Sources/lsRegisterURL/Options.cpp
+++ b/Libraries/builtin/Sources/lsRegisterURL/Options.cpp
@@ -26,11 +26,6 @@ parseArgument(std::vector<std::string> const &args, std::vector<std::string>::co
 {
     std::string const &arg = **it;
 
-    if (_input.empty()) {
-        _input = arg;
-        return std::make_pair(true, std::string());
-    } else {
-        return std::make_pair(false, "multiple input files");
-    }
+    return libutil::Options::Current<std::string>(&_input, arg);
 }
 

--- a/Libraries/builtin/Sources/productPackagingUtility/Options.cpp
+++ b/Libraries/builtin/Sources/productPackagingUtility/Options.cpp
@@ -27,20 +27,15 @@ parseArgument(std::vector<std::string> const &args, std::vector<std::string>::co
     std::string const &arg = **it;
 
     if (arg == "-removefile") {
-        return libutil::Options::MarkBool(&_removeFile, arg, it);
+        return libutil::Options::Current<bool>(&_removeFile, arg, it);
     } else if (arg == "-entitlements") {
-        return libutil::Options::MarkBool(&_entitlements, arg, it);
+        return libutil::Options::Current<bool>(&_entitlements, arg, it);
     } else if (arg == "-resourcerules") {
-        return libutil::Options::MarkBool(&_resourceRules, arg, it);
+        return libutil::Options::Current<bool>(&_resourceRules, arg, it);
     } else if (arg == "-o") {
-        return libutil::Options::NextString(&_output, args, it);
+        return libutil::Options::Next<std::string>(&_output, args, it);
     } else if (!arg.empty() && arg[0] != '-') {
-        if (_input.empty()) {
-            _input = arg;
-            return std::make_pair(true, std::string());
-        } else {
-            return std::make_pair(false, "multiple inputs");
-        }
+        return libutil::Options::Current<std::string>(&_input, arg);
     } else {
         return std::make_pair(false, "unknown argument " + arg);
     }

--- a/Libraries/builtin/Sources/validationUtility/Options.cpp
+++ b/Libraries/builtin/Sources/validationUtility/Options.cpp
@@ -27,15 +27,9 @@ parseArgument(std::vector<std::string> const &args, std::vector<std::string>::co
     std::string const &arg = **it;
 
     if (arg == "-validate-for-store") {
-        return libutil::Options::MarkBool(&_validateForStore, arg, it);
+        return libutil::Options::Current<bool>(&_validateForStore, arg, it);
     } else if (!arg.empty() && arg[0] != '-') {
-        if (_input.empty()) {
-            _input = arg;
-            return std::make_pair(true, std::string());
-        } else {
-            return std::make_pair(false, "multiple inputs");
-        }
-        return std::make_pair(true, std::string());
+        return libutil::Options::Current<std::string>(&_input, arg);
     } else {
         return std::make_pair(false, "unknown argument " + arg);
     }

--- a/Libraries/libbom/Tools/lsbom.cpp
+++ b/Libraries/libbom/Tools/lsbom.cpp
@@ -18,42 +18,42 @@
 
 class Options {
 private:
-    bool _help;
+    ext::optional<bool> _help;
 
 private:
-    bool _includeBlockDevices;
-    bool _includeCharacterDevices;
-    bool _includeDirectories;
-    bool _includeFiles;
-    bool _includeSymbolicLinks;
+    ext::optional<bool> _includeBlockDevices;
+    ext::optional<bool> _includeCharacterDevices;
+    ext::optional<bool> _includeDirectories;
+    ext::optional<bool> _includeFiles;
+    ext::optional<bool> _includeSymbolicLinks;
 
 private:
-    bool _printMTime;
-    bool _onlyPath;
-    bool _noModes;
+    ext::optional<bool> _printMTime;
+    ext::optional<bool> _onlyPath;
+    ext::optional<bool> _noModes;
 
 private:
-    std::string _arch;
+    ext::optional<std::string> _arch;
 
 private:
-    bool _printChecksum;
-    bool _printFileName;
-    bool _printFileNameQuoted;
-    bool _printGroupID;
-    bool _printGroupName;
-    bool _printPermissions;
-    bool _printPermissionsText;
-    bool _printFileSize;
-    bool _printFileSizeFormatted;
-    bool _printModificationTime;
-    bool _printModificationTimeFormatted;
-    bool _printUserID;
-    bool _printUserName;
-    bool _printUserGroupID;
-    bool _printUserGroupName;
+    ext::optional<bool> _printChecksum;
+    ext::optional<bool> _printFileName;
+    ext::optional<bool> _printFileNameQuoted;
+    ext::optional<bool> _printGroupID;
+    ext::optional<bool> _printGroupName;
+    ext::optional<bool> _printPermissions;
+    ext::optional<bool> _printPermissionsText;
+    ext::optional<bool> _printFileSize;
+    ext::optional<bool> _printFileSizeFormatted;
+    ext::optional<bool> _printModificationTime;
+    ext::optional<bool> _printModificationTimeFormatted;
+    ext::optional<bool> _printUserID;
+    ext::optional<bool> _printUserName;
+    ext::optional<bool> _printUserGroupID;
+    ext::optional<bool> _printUserGroupName;
 
 private:
-    std::string _input;
+    ext::optional<std::string> _input;
 
 public:
     Options();
@@ -61,66 +61,66 @@ public:
 
 public:
     bool help() const
-    { return _help; }
+    { return _help.value_or(false); }
 
 public:
     bool includeBlockDevices() const
-    { return _includeBlockDevices; }
+    { return _includeBlockDevices.value_or(false); }
     bool includeCharacterDevices() const
-    { return _includeCharacterDevices; }
+    { return _includeCharacterDevices.value_or(false); }
     bool includeDirectories() const
-    { return _includeDirectories; }
+    { return _includeDirectories.value_or(false); }
     bool includeFiles() const
-    { return _includeFiles; }
+    { return _includeFiles.value_or(false); }
     bool includeSymbolicLinks() const
-    { return _includeSymbolicLinks; }
+    { return _includeSymbolicLinks.value_or(false); }
 
 public:
     bool printMTime() const
-    { return _printMTime; }
+    { return _printMTime.value_or(false); }
     bool onlyPath() const
-    { return _onlyPath; }
+    { return _onlyPath.value_or(false); }
     bool noModes() const
-    { return _noModes; }
+    { return _noModes.value_or(false); }
 
 public:
-    std::string const &arch() const
+    ext::optional<std::string> const &arch() const
     { return _arch; }
 
 public:
     bool printChecksum() const
-    { return _printChecksum; }
+    { return _printChecksum.value_or(false); }
     bool printFileName() const
-    { return _printFileName; }
+    { return _printFileName.value_or(false); }
     bool printFileNameQuoted() const
-    { return _printFileNameQuoted; }
+    { return _printFileNameQuoted.value_or(false); }
     bool printGroupID() const
-    { return _printGroupID; }
+    { return _printGroupID.value_or(false); }
     bool printGroupName() const
-    { return _printGroupName; }
+    { return _printGroupName.value_or(false); }
     bool printPermissions() const
-    { return _printPermissions; }
+    { return _printPermissions.value_or(false); }
     bool printPermissionsText() const
-    { return _printPermissionsText; }
+    { return _printPermissionsText.value_or(false); }
     bool printFileSize() const
-    { return _printFileSize; }
+    { return _printFileSize.value_or(false); }
     bool printFileSizeFormatted() const
-    { return _printFileSizeFormatted; }
+    { return _printFileSizeFormatted.value_or(false); }
     bool printModificationTime() const
-    { return _printModificationTime; }
+    { return _printModificationTime.value_or(false); }
     bool printModificationTimeFormatted() const
-    { return _printModificationTimeFormatted; }
+    { return _printModificationTimeFormatted.value_or(false); }
     bool printUserID() const
-    { return _printUserID; }
+    { return _printUserID.value_or(false); }
     bool printUserName() const
-    { return _printUserName; }
+    { return _printUserName.value_or(false); }
     bool printUserGroupID() const
-    { return _printUserGroupID; }
+    { return _printUserGroupID.value_or(false); }
     bool printUserGroupName() const
-    { return _printUserGroupName; }
+    { return _printUserGroupName.value_or(false); }
 
 public:
-    std::string const &input() const
+    ext::optional<std::string> const &input() const
     { return _input; }
 
 private:
@@ -130,31 +130,7 @@ private:
 };
 
 Options::
-Options() :
-    _help(false),
-    _includeBlockDevices(false),
-    _includeCharacterDevices(false),
-    _includeDirectories(false),
-    _includeFiles(false),
-    _includeSymbolicLinks(false),
-    _printMTime(false),
-    _onlyPath(false),
-    _noModes(false),
-    _printChecksum(false),
-    _printFileName(false),
-    _printFileNameQuoted(false),
-    _printGroupID(false),
-    _printGroupName(false),
-    _printPermissions(false),
-    _printPermissionsText(false),
-    _printFileSize(false),
-    _printFileSizeFormatted(false),
-    _printModificationTime(false),
-    _printModificationTimeFormatted(false),
-    _printUserID(false),
-    _printUserName(false),
-    _printUserGroupID(false),
-    _printUserGroupName(false)
+Options()
 {
 }
 
@@ -170,34 +146,33 @@ parseArgument(std::vector<std::string> const &args, std::vector<std::string>::co
     std::string const &arg = **it;
 
     if (arg == "-h" || arg == "--help") {
-        return libutil::Options::MarkBool(&_help, arg, it);
+        return libutil::Options::Current<bool>(&_help, arg, it);
     } else if (arg == "-b") {
-        return libutil::Options::MarkBool(&_includeBlockDevices, arg, it);
+        return libutil::Options::Current<bool>(&_includeBlockDevices, arg, it);
     } else if (arg == "-c") {
-        return libutil::Options::MarkBool(&_includeCharacterDevices, arg, it);
+        return libutil::Options::Current<bool>(&_includeCharacterDevices, arg, it);
     } else if (arg == "-d") {
-        return libutil::Options::MarkBool(&_includeDirectories, arg, it);
+        return libutil::Options::Current<bool>(&_includeDirectories, arg, it);
     } else if (arg == "-f") {
-        return libutil::Options::MarkBool(&_includeFiles, arg, it);
+        return libutil::Options::Current<bool>(&_includeFiles, arg, it);
     } else if (arg == "-l") {
-        return libutil::Options::MarkBool(&_includeSymbolicLinks, arg, it);
+        return libutil::Options::Current<bool>(&_includeSymbolicLinks, arg, it);
     } else if (arg == "-m") {
-        return libutil::Options::MarkBool(&_printMTime, arg, it);
+        return libutil::Options::Current<bool>(&_printMTime, arg, it);
     } else if (arg == "-s") {
-        return libutil::Options::MarkBool(&_onlyPath, arg, it);
+        return libutil::Options::Current<bool>(&_onlyPath, arg, it);
     } else if (arg == "-x") {
-        return libutil::Options::MarkBool(&_noModes, arg, it);
+        return libutil::Options::Current<bool>(&_noModes, arg, it);
     } else if (arg == "--arch") {
-        return libutil::Options::NextString(&_arch, args, it);
+        return libutil::Options::Next<std::string>(&_arch, args, it);
     } else if (arg == "-p") {
-        std::string print;
-
-        auto result = libutil::Options::NextString(&print, args, it);
+        ext::optional<std::string> print;
+        auto result = libutil::Options::Next<std::string>(&print, args, it);
         if (!result.first) {
             return result;
         }
 
-        for (char c : print) {
+        for (char c : *print) {
             switch (c) {
                 case 'c': _printChecksum = true; break;
                 case 'f': _printFileName = true; break;
@@ -221,12 +196,7 @@ parseArgument(std::vector<std::string> const &args, std::vector<std::string>::co
 
         return std::make_pair(true, std::string());
     } else if (!arg.empty() && arg[0] != '-') {
-        if (_input.empty()) {
-            _input = arg;
-            return std::make_pair(true, std::string());
-        } else {
-            return std::make_pair(false, "extra input " + arg);
-        }
+        return libutil::Options::Current<std::string>(&_input, arg);
     } else {
         return std::make_pair(false, "unknown argument " + arg);
     }
@@ -350,10 +320,10 @@ main(int argc, char **argv)
     /*
      * Validate options.
      */
-    if (options.input().empty()) {
+    if (!options.input()) {
         return Help("input is required");
     }
-    if (!options.arch().empty()) {
+    if (options.arch()) {
         fprintf(stderr, "warning: arch argument not yet implemented\n");
     }
 
@@ -368,7 +338,7 @@ main(int argc, char **argv)
     /*
      * Load the BOM file.
      */
-    struct bom_context_memory memory = bom_context_memory_file(options.input().c_str(), false, 0);
+    struct bom_context_memory memory = bom_context_memory_file(options.input()->c_str(), false, 0);
     auto bom = std::unique_ptr<struct bom_context, decltype(&bom_free)>(bom_alloc_load(memory), bom_free);
     if (bom == nullptr) {
         fprintf(stderr, "error: failed to load BOM\n");
@@ -491,5 +461,4 @@ main(int argc, char **argv)
 
     return 0;
 }
-
 

--- a/Libraries/libutil/Headers/libutil/Options.h
+++ b/Libraries/libutil/Headers/libutil/Options.h
@@ -12,25 +12,52 @@
 
 #include <string>
 #include <vector>
+#include <ext/optional>
 
 namespace libutil {
 
+/*
+ * Utilities for parsing command-line options.
+ */
 class Options {
 private:
     Options();
     ~Options();
 
 public:
+    /*
+     * Parse the next argument as the specified type.
+     */
+    template<typename T>
     static std::pair<bool, std::string>
-    NextString(std::string *result, std::vector<std::string> const &args, std::vector<std::string>::const_iterator *it, bool allowDuplicate = false);
+    Next(ext::optional<T> *result, std::vector<std::string> const &args, std::vector<std::string>::const_iterator *it, bool allowDuplicate = false);
+
+    /*
+     * Parse the next argument as the specified type, appending it to a list.
+     */
+    template<typename T>
     static std::pair<bool, std::string>
-    NextInt(int *result, std::vector<std::string> const &args, std::vector<std::string>::const_iterator *it, bool allowDuplicate = false);
-    static std::pair<bool, std::string>
-    NextBool(bool *result, std::vector<std::string> const &args, std::vector<std::string>::const_iterator *it, bool allowDuplicate = false);
-    static std::pair<bool, std::string>
-    MarkBool(bool *result, std::string const &arg, bool allowDuplicate = false);
+    AppendNext(std::vector<T> *result, std::vector<std::string> const &args, std::vector<std::string>::const_iterator *it);
 
 public:
+    /*
+     * Parse the current argument as the specified type.
+     */
+    template<typename T>
+    static std::pair<bool, std::string>
+    Current(ext::optional<T> *result, std::string const &arg, bool allowDuplicate = false);
+
+    /*
+     * Parse the current argument as the specified type, appending it to a list.
+     */
+    template<typename T>
+    static std::pair<bool, std::string>
+    AppendCurrent(std::vector<T> *result, std::string const &arg);
+
+public:
+    /*
+     * Parse arguments into the specified options type.
+     */
     template<typename T>
     static std::pair<bool, std::string>
     Parse(T *options, std::vector<std::string> const &args)

--- a/Libraries/xcdriver/Headers/xcdriver/Options.h
+++ b/Libraries/xcdriver/Headers/xcdriver/Options.h
@@ -21,74 +21,74 @@ namespace xcdriver {
 
 class Options {
 private:
-    bool        _usage;
-    bool        _help;
-    bool        _verbose;
-    bool        _license;
-    bool        _checkFirstLaunchStatus;
-    bool        _version;
+    ext::optional<bool>        _usage;
+    ext::optional<bool>        _help;
+    ext::optional<bool>        _verbose;
+    ext::optional<bool>        _license;
+    ext::optional<bool>        _checkFirstLaunchStatus;
+    ext::optional<bool>        _version;
 
 private:
-    std::string _project;
-    std::vector<std::string> _target;
-    bool        _allTargets;
-    std::string _workspace;
-    std::string _scheme;
-    std::string _configuration;
-    std::string _arch;
-    std::string _sdk;
-    std::string _toolchain;
-    std::string _destination;
-    std::string _destinationTimeout;
+    ext::optional<std::string> _project;
+    std::vector<std::string>   _target;
+    ext::optional<bool>        _allTargets;
+    ext::optional<std::string> _workspace;
+    ext::optional<std::string> _scheme;
+    ext::optional<std::string> _configuration;
+    ext::optional<std::string> _arch;
+    ext::optional<std::string> _sdk;
+    ext::optional<std::string> _toolchain;
+    ext::optional<std::string> _destination;
+    ext::optional<std::string> _destinationTimeout;
 
 private:
-    std::string _formatter;
-    std::string _executor;
-    bool        _generate;
+    ext::optional<std::string> _formatter;
+    ext::optional<std::string> _executor;
+    ext::optional<bool>        _generate;
 
 private:
-    bool        _parallelizeTargets;
-    int         _jobs;
-    bool        _dryRun;
-    bool        _hideShellScriptEnvironment;
+    ext::optional<bool>        _parallelizeTargets;
+    ext::optional<int>         _jobs;
+    ext::optional<bool>        _dryRun;
+    ext::optional<bool>        _hideShellScriptEnvironment;
 
 private:
-    bool        _list;
-    bool        _showSDKs;
-    bool        _showBuildSettings;
+    ext::optional<bool>        _list;
+    ext::optional<bool>        _showSDKs;
+    ext::optional<bool>        _showBuildSettings;
 
 private:
-    std::string _xcconfig;
+    ext::optional<std::string> _xcconfig;
     std::vector<pbxsetting::Setting> _settings;
 
 private:
-    std::string _findExecutable;
-    std::string _findLibrary;
+    ext::optional<std::string> _findExecutable;
+    ext::optional<std::string> _findLibrary;
 
 private:
-    bool        _enableAddressSanitizer;
-    bool        _enableCodeCoverage;
+    ext::optional<bool>        _enableAddressSanitizer;
+    ext::optional<bool>        _enableCodeCoverage;
 
 private:
-    std::string _resultBundlePath;
-    std::string _derivedDataPath;
+    ext::optional<std::string> _resultBundlePath;
+    ext::optional<std::string> _derivedDataPath;
 
 private:
-    bool        _exportArchive;
-    std::string _archivePath;
-    std::string _exportPath;
-    std::string _exportOptionsPlist;
+    ext::optional<bool>        _exportArchive;
+    ext::optional<std::string> _archivePath;
+    ext::optional<std::string> _exportPath;
+    ext::optional<std::string> _exportOptionsPlist;
 
 private:
-    bool        _skipUnavailableActions;
-    std::vector<std::string> _actions;
+    ext::optional<bool>        _skipUnavailableActions;
+    std::vector<std::string>   _actions;
 
 private:
-    bool        _exportLocalizations;
-    bool        _importLocalizations;
-    std::string _localizationPath;
-    std::string _exportLanguage;
-    bool        _forceImport;
+    ext::optional<bool>        _exportLocalizations;
+    ext::optional<bool>        _importLocalizations;
+    ext::optional<std::string> _localizationPath;
+    ext::optional<std::string> _exportLanguage;
+    ext::optional<bool>        _forceImport;
 
 public:
     Options();
@@ -96,122 +96,122 @@ public:
 
 public:
     bool usage() const
-    { return _usage; }
+    { return _usage.value_or(false); }
     bool help() const
-    { return _help; }
+    { return _help.value_or(false); }
     bool verbose() const
-    { return _verbose; }
+    { return _verbose.value_or(false); }
     bool license() const
-    { return _license; }
+    { return _license.value_or(false); }
     bool checkFirstLaunchStatus() const
-    { return _checkFirstLaunchStatus; }
+    { return _checkFirstLaunchStatus.value_or(false); }
     bool version() const
-    { return _version; }
+    { return _version.value_or(false); }
 
 public:
-    std::string const &project() const
+    ext::optional<std::string> const &project() const
     { return _project; }
     std::vector<std::string> const &target() const
     { return _target; }
     bool allTargets() const
-    { return _allTargets; }
-    std::string const &workspace() const
+    { return _allTargets.value_or(false); }
+    ext::optional<std::string> const &workspace() const
     { return _workspace; }
-    std::string const &scheme() const
+    ext::optional<std::string> const &scheme() const
     { return _scheme; }
-    std::string const &configuration() const
+    ext::optional<std::string> const &configuration() const
     { return _configuration; }
-    std::string const &arch() const
+    ext::optional<std::string> const &arch() const
     { return _arch; }
-    std::string const &sdk() const
+    ext::optional<std::string> const &sdk() const
     { return _sdk; }
-    std::string const &toolchain() const
+    ext::optional<std::string> const &toolchain() const
     { return _toolchain; }
-    std::string const &destination() const
+    ext::optional<std::string> const &destination() const
     { return _destination; }
-    std::string const &destinationTimeout() const
+    ext::optional<std::string> const &destinationTimeout() const
     { return _destinationTimeout; }
 
 public:
     /* Extension. */
-    std::string const &formatter() const
+    ext::optional<std::string> const &formatter() const
     { return _formatter; }
     /* Extension. */
-    std::string const &executor() const
+    ext::optional<std::string> const &executor() const
     { return _executor; }
     /* Extension. */
     bool generate() const
-    { return _generate; }
+    { return _generate.value_or(false); }
 
 public:
     bool parallelizeTargets() const
-    { return _parallelizeTargets; }
-    int jobs() const
+    { return _parallelizeTargets.value_or(false); }
+    ext::optional<int> jobs() const
     { return _jobs; }
     bool dryRun() const
-    { return _dryRun; }
+    { return _dryRun.value_or(false); }
     bool hideShellScriptEnvironment() const
-    { return _hideShellScriptEnvironment; }
+    { return _hideShellScriptEnvironment.value_or(false); }
 
 public:
     bool list() const
-    { return _list; }
+    { return _list.value_or(false); }
     bool showSDKs() const
-    { return _showSDKs; }
+    { return _showSDKs.value_or(false); }
     bool showBuildSettings() const
-    { return _showBuildSettings; }
+    { return _showBuildSettings.value_or(false); }
 
 public:
-    std::string const &xcconfig() const
+    ext::optional<std::string> const &xcconfig() const
     { return _xcconfig; }
     std::vector<pbxsetting::Setting> const &settings() const
     { return _settings; }
 
 public:
-    std::string const &findExecutable() const
+    ext::optional<std::string> const &findExecutable() const
     { return _findExecutable; }
-    std::string const &findLibrary() const
+    ext::optional<std::string> const &findLibrary() const
     { return _findLibrary; }
 
 public:
     bool enableAddressSanitizer() const
-    { return _enableAddressSanitizer; }
+    { return _enableAddressSanitizer.value_or(false); }
     bool enableCodeCoverage() const
-    { return _enableCodeCoverage; }
+    { return _enableCodeCoverage.value_or(false); }
 
 public:
-    std::string const &resultBundlePath() const
+    ext::optional<std::string> const &resultBundlePath() const
     { return _resultBundlePath; }
-    std::string const &derivedDataPath() const
+    ext::optional<std::string> const &derivedDataPath() const
     { return _derivedDataPath; }
 
 public:
     bool exportArchive() const
-    { return _exportArchive; }
-    std::string const &archivePath() const
+    { return _exportArchive.value_or(false); }
+    ext::optional<std::string> const &archivePath() const
     { return _archivePath; }
-    std::string const &exportPath() const
+    ext::optional<std::string> const &exportPath() const
     { return _exportPath; }
-    std::string const &exportOptionsPlist() const
+    ext::optional<std::string> const &exportOptionsPlist() const
     { return _exportOptionsPlist; }
 
 public:
     bool skipUnavailableActions() const
-    { return _skipUnavailableActions; }
+    { return _skipUnavailableActions.value_or(false); }
     std::vector<std::string> const &actions() const
     { return _actions; }
 
 public:
     bool exportLocalizations() const
-    { return _exportLocalizations; }
+    { return _exportLocalizations.value_or(false); }
     bool importLocalizations() const
-    { return _importLocalizations; }
-    std::string const &localizationPath() const
+    { return _importLocalizations.value_or(false); }
+    ext::optional<std::string> const &localizationPath() const
     { return _localizationPath; }
-    std::string const &exportLanguage() const
+    ext::optional<std::string> const &exportLanguage() const
     { return _exportLanguage; }
     bool forceImport() const
-    { return _forceImport; }
+    { return _forceImport.value_or(false); }
 
 private:
     friend class libutil::Options;

--- a/Libraries/xcdriver/Sources/Action.cpp
+++ b/Libraries/xcdriver/Sources/Action.cpp
@@ -29,20 +29,20 @@ CreateOverrideLevels(Options const &options, pbxsetting::Environment const &envi
     std::vector<pbxsetting::Level> levels;
 
     std::vector<pbxsetting::Setting> settings;
-    if (!options.sdk().empty()) {
-        settings.push_back(pbxsetting::Setting::Create("SDKROOT", options.sdk()));
+    if (options.sdk()) {
+        settings.push_back(pbxsetting::Setting::Create("SDKROOT", *options.sdk()));
     }
-    if (!options.arch().empty()) {
-        settings.push_back(pbxsetting::Setting::Create("ARCHS", options.arch()));
+    if (options.arch()) {
+        settings.push_back(pbxsetting::Setting::Create("ARCHS", *options.arch()));
     }
     levels.push_back(pbxsetting::Level(settings));
 
     levels.push_back(options.settings());
 
-    if (!options.xcconfig().empty()) {
-        pbxsetting::XC::Config::shared_ptr config = pbxsetting::XC::Config::Open(options.xcconfig(), environment);
+    if (options.xcconfig()) {
+        pbxsetting::XC::Config::shared_ptr config = pbxsetting::XC::Config::Open(*options.xcconfig(), environment);
         if (config == nullptr) {
-            fprintf(stderr, "warning: unable to open xcconfig '%s'\n", options.xcconfig().c_str());
+            fprintf(stderr, "warning: unable to open xcconfig '%s'\n", options.xcconfig()->c_str());
         } else {
             levels.push_back(config->level());
         }
@@ -66,13 +66,13 @@ xcexecution::Parameters Action::
 CreateParameters(Options const &options, std::vector<pbxsetting::Level> const &overrideLevels)
 {
     return xcexecution::Parameters(
-        !options.workspace().empty() ? ext::make_optional(options.workspace()) : ext::nullopt,
-        !options.project().empty() ? ext::make_optional(options.project()) : ext::nullopt,
-        !options.scheme().empty() ? ext::make_optional(options.scheme()) : ext::nullopt,
-        !options.target().empty() ? ext::make_optional(options.target()) : ext::nullopt,
+        options.workspace(),
+        options.project(),
+        options.scheme(),
+        options.target(),
         options.allTargets(),
         options.actions(),
-        !options.configuration().empty() ? ext::make_optional(options.configuration()) : ext::nullopt,
+        options.configuration(),
         overrideLevels);
 }
 
@@ -110,7 +110,7 @@ Determine(Options const &options)
         return CheckFirstLaunch;
     } else if (options.showSDKs()) {
         return ShowSDKs;
-    } else if (!options.findLibrary().empty() || !options.findExecutable().empty()) {
+    } else if (options.findLibrary() || options.findExecutable()) {
         return Find;
     } else if (options.exportArchive()) {
         return ExportArchive;

--- a/Libraries/xcdriver/Sources/FindAction.cpp
+++ b/Libraries/xcdriver/Sources/FindAction.cpp
@@ -45,10 +45,7 @@ Run(Filesystem const *filesystem, Options const &options)
         return 1;
     }
 
-    std::string sdk = options.sdk();
-    if (sdk.empty()) {
-        sdk = "macosx";
-    }
+    std::string sdk = options.sdk().value_or("macosx");
 
     xcsdk::SDK::Target::shared_ptr target = manager->findTarget(sdk);
     if (target == nullptr) {
@@ -56,16 +53,16 @@ Run(Filesystem const *filesystem, Options const &options)
         return 1;
     }
 
-    if (!options.findExecutable().empty()) {
-        ext::optional<std::string> executable = filesystem->findExecutable(options.findExecutable(), target->executablePaths());
+    if (options.findExecutable()) {
+        ext::optional<std::string> executable = filesystem->findExecutable(*options.findExecutable(), target->executablePaths());
         if (!executable) {
-            fprintf(stderr, "error: '%s' not found\n", options.findExecutable().c_str());
+            fprintf(stderr, "error: '%s' not found\n", options.findExecutable()->c_str());
             return 1;
         }
 
         printf("%s\n", executable->c_str());
         return 0;
-    } else if (!options.findLibrary().empty()) {
+    } else if (options.findLibrary()) {
         fprintf(stderr, "warning: finding libraries is not supported\n");
         return 0;
     } else {

--- a/Libraries/xcdriver/Sources/Options.cpp
+++ b/Libraries/xcdriver/Sources/Options.cpp
@@ -12,29 +12,7 @@
 using xcdriver::Options;
 
 Options::
-Options() :
-    _usage                     (false),
-    _help                      (false),
-    _verbose                   (false),
-    _license                   (false),
-    _checkFirstLaunchStatus    (false),
-    _version                   (false),
-    _allTargets                (false),
-    _generate                  (false),
-    _parallelizeTargets        (false),
-    _jobs                      (0),
-    _dryRun                    (false),
-    _hideShellScriptEnvironment(false),
-    _list                      (false),
-    _showSDKs                  (false),
-    _showBuildSettings         (false),
-    _enableAddressSanitizer    (false),
-    _enableCodeCoverage        (false),
-    _exportArchive             (false),
-    _skipUnavailableActions    (false),
-    _exportLocalizations       (false),
-    _importLocalizations       (false),
-    _forceImport               (false)
+Options()
 {
 }
 
@@ -49,100 +27,93 @@ parseArgument(std::vector<std::string> const &args, std::vector<std::string>::co
     std::string const &arg = **it;
 
     if (arg == "-usage") {
-        return libutil::Options::MarkBool(&_usage, arg);
+        return libutil::Options::Current<bool>(&_usage, arg);
     } else if (arg == "-help") {
-        return libutil::Options::MarkBool(&_help, arg);
+        return libutil::Options::Current<bool>(&_help, arg);
     } else if (arg == "-verbose") {
-        return libutil::Options::MarkBool(&_verbose, arg);
+        return libutil::Options::Current<bool>(&_verbose, arg);
     } else if (arg == "-license") {
-        return libutil::Options::MarkBool(&_license, arg);
+        return libutil::Options::Current<bool>(&_license, arg);
     } else if (arg == "-checkFirstLaunchStatus") {
-        return libutil::Options::MarkBool(&_checkFirstLaunchStatus, arg);
+        return libutil::Options::Current<bool>(&_checkFirstLaunchStatus, arg);
     } else if (arg == "-project") {
-        return libutil::Options::NextString(&_project, args, it);
+        return libutil::Options::Next<std::string>(&_project, args, it);
     } else if (arg == "-target") {
-        std::string target;
-        auto result = libutil::Options::NextString(&target, args, it);
-        if (!result.first) {
-            return result;
-        }
-
-        _target.push_back(target);
-        return result;
+        return libutil::Options::AppendNext<std::string>(&_target, args, it);
     } else if (arg == "-alltargets") {
-        return libutil::Options::MarkBool(&_allTargets, arg);
+        return libutil::Options::Current<bool>(&_allTargets, arg);
     } else if (arg == "-workspace") {
-        return libutil::Options::NextString(&_workspace, args, it);
+        return libutil::Options::Next<std::string>(&_workspace, args, it);
     } else if (arg == "-scheme") {
-        return libutil::Options::NextString(&_scheme, args, it);
+        return libutil::Options::Next<std::string>(&_scheme, args, it);
     } else if (arg == "-configuration") {
-        return libutil::Options::NextString(&_configuration, args, it);
+        return libutil::Options::Next<std::string>(&_configuration, args, it);
     } else if (arg == "-xcconfig") {
-        return libutil::Options::NextString(&_xcconfig, args, it);
+        return libutil::Options::Next<std::string>(&_xcconfig, args, it);
     } else if (arg == "-arch") {
-        return libutil::Options::NextString(&_arch, args, it);
+        return libutil::Options::Next<std::string>(&_arch, args, it);
     } else if (arg == "-sdk") {
-        return libutil::Options::NextString(&_sdk, args, it);
+        return libutil::Options::Next<std::string>(&_sdk, args, it);
     } else if (arg == "-toolchain") {
-        return libutil::Options::NextString(&_toolchain, args, it);
+        return libutil::Options::Next<std::string>(&_toolchain, args, it);
     } else if (arg == "-destination") {
-        return libutil::Options::NextString(&_destination, args, it);
+        return libutil::Options::Next<std::string>(&_destination, args, it);
     } else if (arg == "-destinationtimeout") {
-        return libutil::Options::NextString(&_destinationTimeout, args, it);
+        return libutil::Options::Next<std::string>(&_destinationTimeout, args, it);
     } else if (arg == "-parallelizeTargets") {
-        return libutil::Options::MarkBool(&_parallelizeTargets, arg);
+        return libutil::Options::Current<bool>(&_parallelizeTargets, arg);
     } else if (arg == "-jobs") {
-        return libutil::Options::NextInt(&_jobs, args, it);
+        return libutil::Options::Next<int>(&_jobs, args, it);
     } else if (arg == "-dryrun" || arg == "-n") {
-        return libutil::Options::MarkBool(&_dryRun, arg);
+        return libutil::Options::Current<bool>(&_dryRun, arg);
     } else if (arg == "-hideShellScriptEnvironment") {
-        return libutil::Options::MarkBool(&_hideShellScriptEnvironment, arg);
+        return libutil::Options::Current<bool>(&_hideShellScriptEnvironment, arg);
     } else if (arg == "-showsdks") {
-        return libutil::Options::MarkBool(&_showSDKs, arg);
+        return libutil::Options::Current<bool>(&_showSDKs, arg);
     } else if (arg == "-showBuildSettings") {
-        return libutil::Options::MarkBool(&_showBuildSettings, arg);
+        return libutil::Options::Current<bool>(&_showBuildSettings, arg);
     } else if (arg == "-list") {
-        return libutil::Options::MarkBool(&_list, arg);
+        return libutil::Options::Current<bool>(&_list, arg);
     } else if (arg == "-find" || arg == "-find-executable") {
-        return libutil::Options::NextString(&_findExecutable, args, it);
+        return libutil::Options::Next<std::string>(&_findExecutable, args, it);
     } else if (arg == "-find-library") {
-        return libutil::Options::NextString(&_findLibrary, args, it);
+        return libutil::Options::Next<std::string>(&_findLibrary, args, it);
     } else if (arg == "-version") {
-        return libutil::Options::MarkBool(&_version, arg);
+        return libutil::Options::Current<bool>(&_version, arg);
     } else if (arg == "-enableAddressSanitizer") {
-        return libutil::Options::NextBool(&_enableAddressSanitizer, args, it);
+        return libutil::Options::Next<bool>(&_enableAddressSanitizer, args, it);
     } else if (arg == "-resultBundlePath") {
-        return libutil::Options::NextString(&_resultBundlePath, args, it);
+        return libutil::Options::Next<std::string>(&_resultBundlePath, args, it);
     } else if (arg == "-derivedDataPath") {
-        return libutil::Options::NextString(&_derivedDataPath, args, it);
+        return libutil::Options::Next<std::string>(&_derivedDataPath, args, it);
     } else if (arg == "-archivePath") {
-        return libutil::Options::NextString(&_archivePath, args, it);
+        return libutil::Options::Next<std::string>(&_archivePath, args, it);
     } else if (arg == "-exportArchive") {
-        return libutil::Options::MarkBool(&_exportArchive, arg);
+        return libutil::Options::Current<bool>(&_exportArchive, arg);
     } else if (arg == "-exportOptionsPlist") {
-        return libutil::Options::NextString(&_exportOptionsPlist, args, it);
+        return libutil::Options::Next<std::string>(&_exportOptionsPlist, args, it);
     } else if (arg == "-enableCodeCoverage") {
-        return libutil::Options::NextBool(&_enableCodeCoverage, args, it);
+        return libutil::Options::Next<bool>(&_enableCodeCoverage, args, it);
     } else if (arg == "-exportPath") {
-        return libutil::Options::NextString(&_exportPath, args, it);
+        return libutil::Options::Next<std::string>(&_exportPath, args, it);
     } else if (arg == "-skipUnavailableActions") {
-        return libutil::Options::MarkBool(&_skipUnavailableActions, arg);
+        return libutil::Options::Current<bool>(&_skipUnavailableActions, arg);
     } else if (arg == "-exportLocalizations") {
-        return libutil::Options::MarkBool(&_exportLocalizations, arg);
+        return libutil::Options::Current<bool>(&_exportLocalizations, arg);
     } else if (arg == "-importLocalizations") {
-        return libutil::Options::MarkBool(&_importLocalizations, arg);
+        return libutil::Options::Current<bool>(&_importLocalizations, arg);
     } else if (arg == "-localizationPath") {
-        return libutil::Options::NextString(&_localizationPath, args, it);
+        return libutil::Options::Next<std::string>(&_localizationPath, args, it);
     } else if (arg == "-exportLanguage") {
-        return libutil::Options::NextString(&_exportLanguage, args, it);
+        return libutil::Options::Next<std::string>(&_exportLanguage, args, it);
     } else if (arg == "-forceImport") {
-        return libutil::Options::MarkBool(&_forceImport, arg);
+        return libutil::Options::Current<bool>(&_forceImport, arg);
     } else if (arg == "-executor") {
-        return libutil::Options::NextString(&_executor, args, it);
+        return libutil::Options::Next<std::string>(&_executor, args, it);
     } else if (arg == "-formatter") {
-        return libutil::Options::NextString(&_formatter, args, it);
+        return libutil::Options::Next<std::string>(&_formatter, args, it);
     } else if (arg == "-generate") {
-        return libutil::Options::MarkBool(&_generate, arg);
+        return libutil::Options::Current<bool>(&_generate, arg);
     } else if (!arg.empty() && arg[0] != '-') {
         if (arg.find('=') != std::string::npos) {
             _settings.push_back(pbxsetting::Setting::Parse(arg));

--- a/Libraries/xcdriver/Sources/VersionAction.cpp
+++ b/Libraries/xcdriver/Sources/VersionAction.cpp
@@ -35,7 +35,7 @@ VersionAction::
 int VersionAction::
 Run(Filesystem const *filesystem, Options const &options)
 {
-    if (options.sdk().empty()) {
+    if (!options.sdk()) {
         // TODO(grp): Real version numbers.
         printf("xcbuild version 0.1\n");
         printf("Build version 1\n");
@@ -53,9 +53,9 @@ Run(Filesystem const *filesystem, Options const &options)
             return 1;
         }
 
-        xcsdk::SDK::Target::shared_ptr target = manager->findTarget(options.sdk());
+        xcsdk::SDK::Target::shared_ptr target = manager->findTarget(*options.sdk());
         if (target == nullptr) {
-            fprintf(stderr, "error: cannot find sdk '%s'\n", options.sdk().c_str());
+            fprintf(stderr, "error: cannot find sdk '%s'\n", options.sdk()->c_str());
             return 1;
         }
 

--- a/Libraries/xcsdk/Tools/xcode-select.cpp
+++ b/Libraries/xcsdk/Tools/xcode-select.cpp
@@ -18,16 +18,16 @@ using libutil::Filesystem;
 
 class Options {
 private:
-    bool _help;
-    bool _version;
+    ext::optional<bool>        _help;
+    ext::optional<bool>        _version;
 
 private:
-    bool _printPath;
-    bool _resetPath;
+    ext::optional<bool>        _printPath;
+    ext::optional<bool>        _resetPath;
     ext::optional<std::string> _switchPath;
 
 private:
-    bool _install;
+    ext::optional<bool>        _install;
 
 public:
     Options();
@@ -35,21 +35,21 @@ public:
 
 public:
     bool help() const
-    { return _help; }
+    { return _help.value_or(false); }
     bool version() const
-    { return _version; }
+    { return _version.value_or(false); }
 
 public:
     bool printPath() const
-    { return _printPath; }
+    { return _printPath.value_or(false); }
     bool resetPath() const
-    { return _resetPath; }
+    { return _resetPath.value_or(false); }
     ext::optional<std::string> const &switchPath() const
     { return _switchPath; }
 
 public:
     bool install() const
-    { return _install; }
+    { return _install.value_or(false); }
 
 private:
     friend class libutil::Options;
@@ -58,12 +58,7 @@ private:
 };
 
 Options::
-Options() :
-    _help     (false),
-    _version  (false),
-    _printPath(false),
-    _resetPath(false),
-    _install  (false)
+Options()
 {
 }
 
@@ -78,25 +73,17 @@ parseArgument(std::vector<std::string> const &args, std::vector<std::string>::co
     std::string const &arg = **it;
 
     if (arg == "-h" || arg == "--help") {
-        return libutil::Options::MarkBool(&_help, arg, it);
+        return libutil::Options::Current<bool>(&_help, arg, it);
     } else if (arg == "-v" || arg == "--version" || arg == "-version") {
-        return libutil::Options::MarkBool(&_version, arg, it);
+        return libutil::Options::Current<bool>(&_version, arg, it);
     } else if (arg == "-p" || arg == "--print-path" || arg == "-print-path") {
-        return libutil::Options::MarkBool(&_printPath, arg, it);
+        return libutil::Options::Current<bool>(&_printPath, arg, it);
     } else if (arg == "-r" || arg == "--reset") {
-        return libutil::Options::MarkBool(&_resetPath, arg, it);
+        return libutil::Options::Current<bool>(&_resetPath, arg, it);
     } else if (arg == "-s" || arg == "--switch" || arg == "-switch") {
-        std::string switchPath;
-
-        auto result = libutil::Options::NextString(&switchPath, args, it);
-        if (!result.first) {
-            return result;
-        }
-
-        _switchPath = switchPath;
-        return result;
+        return libutil::Options::Next<std::string>(&_switchPath, args, it);
     } else if (arg == "--install") {
-        return libutil::Options::MarkBool(&_install, arg, it);
+        return libutil::Options::Current<bool>(&_install, arg, it);
     } else {
         return std::make_pair(false, "unknown argument " + arg);
     }

--- a/Libraries/xcsdk/Tools/xcrun.cpp
+++ b/Libraries/xcsdk/Tools/xcrun.cpp
@@ -27,36 +27,36 @@ using libutil::Subprocess;
 
 class Options {
 private:
-    bool                     _help;
-    bool                     _version;
+    ext::optional<bool>        _help;
+    ext::optional<bool>        _version;
 
 private:
-    bool                     _run;
-    bool                     _find;
+    ext::optional<bool>        _run;
+    ext::optional<bool>        _find;
 
 private:
-    bool                     _showSDKPath;
-    bool                     _showSDKVersion;
-    bool                     _showSDKBuildVersion;
-    bool                     _showSDKPlatformPath;
-    bool                     _showSDKPlatformVersion;
+    ext::optional<bool>        _showSDKPath;
+    ext::optional<bool>        _showSDKVersion;
+    ext::optional<bool>        _showSDKBuildVersion;
+    ext::optional<bool>        _showSDKPlatformPath;
+    ext::optional<bool>        _showSDKPlatformVersion;
 
 private:
-    bool                     _log;
-    bool                     _verbose;
+    ext::optional<bool>        _log;
+    ext::optional<bool>        _verbose;
 
 private:
-    bool                     _noCache;
-    bool                     _killCache;
+    ext::optional<bool>        _noCache;
+    ext::optional<bool>        _killCache;
 
 private:
-    std::string              _toolchain;
-    std::string              _SDK;
+    ext::optional<std::string> _toolchain;
+    ext::optional<std::string> _SDK;
 
 private:
-    bool                     _separator;
-    std::string              _tool;
-    std::vector<std::string> _args;
+    ext::optional<bool>        _separator;
+    ext::optional<std::string> _tool;
+    std::vector<std::string>   _args;
 
 public:
     Options();
@@ -64,48 +64,48 @@ public:
 
 public:
     bool help() const
-    { return _help; }
+    { return _help.value_or(false); }
     bool version() const
-    { return _version; }
+    { return _version.value_or(false); }
 
 public:
     bool run() const
-    { return _run; }
+    { return _run.value_or(false); }
     bool find() const
-    { return _find; }
+    { return _find.value_or(false); }
 
 public:
     bool showSDKPath() const
-    { return _showSDKPath; }
+    { return _showSDKPath.value_or(false); }
     bool showSDKVersion() const
-    { return _showSDKVersion; }
+    { return _showSDKVersion.value_or(false); }
     bool showSDKBuildVersion() const
-    { return _showSDKBuildVersion; }
+    { return _showSDKBuildVersion.value_or(false); }
     bool showSDKPlatformPath() const
-    { return _showSDKPlatformPath; }
+    { return _showSDKPlatformPath.value_or(false); }
     bool showSDKPlatformVersion() const
-    { return _showSDKPlatformVersion; }
+    { return _showSDKPlatformVersion.value_or(false); }
 
 public:
     bool log() const
-    { return _log; }
+    { return _log.value_or(false); }
     bool verbose() const
-    { return _verbose; }
+    { return _verbose.value_or(false); }
 
 public:
     bool noCache() const
-    { return _noCache; }
+    { return _noCache.value_or(false); }
     bool killCache() const
-    { return _killCache; }
+    { return _killCache.value_or(false); }
 
 public:
-    std::string const &SDK() const
+    ext::optional<std::string> const &SDK() const
     { return _SDK; }
-    std::string const &toolchain() const
+    ext::optional<std::string> const &toolchain() const
     { return _toolchain; }
 
 public:
-    std::string const &tool() const
+    ext::optional<std::string> const &tool() const
     { return _tool; }
     std::vector<std::string> const &args() const
     { return _args; }
@@ -117,21 +117,7 @@ private:
 };
 
 Options::
-Options() :
-    _help                  (false),
-    _version               (false),
-    _run                   (false),
-    _find                  (false),
-    _showSDKPath           (false),
-    _showSDKVersion        (false),
-    _showSDKBuildVersion   (false),
-    _showSDKPlatformPath   (false),
-    _showSDKPlatformVersion(false),
-    _log                   (false),
-    _verbose               (false),
-    _noCache               (false),
-    _killCache             (false),
-    _separator             (false)
+Options()
 {
 }
 
@@ -147,42 +133,42 @@ parseArgument(std::vector<std::string> const &args, std::vector<std::string>::co
 
     if (!_separator) {
         if (arg == "-h" || arg == "--help" || arg == "-help") {
-            return libutil::Options::MarkBool(&_help, arg, it);
+            return libutil::Options::Current<bool>(&_help, arg, it);
         } else if (arg == "--version" || arg == "-version") {
-            return libutil::Options::MarkBool(&_version, arg, it);
+            return libutil::Options::Current<bool>(&_version, arg, it);
         } else if (arg == "-r" || arg == "--run" || arg == "-run") {
-            return libutil::Options::MarkBool(&_run, arg, it);
+            return libutil::Options::Current<bool>(&_run, arg, it);
         } else if (arg == "-f" || arg == "--find" || arg == "-find") {
-            return libutil::Options::MarkBool(&_find, arg, it);
+            return libutil::Options::Current<bool>(&_find, arg, it);
         } else if (arg == "--show-sdk-path" || arg == "-show-sdk-path") {
-            return libutil::Options::MarkBool(&_showSDKPath, arg, it);
+            return libutil::Options::Current<bool>(&_showSDKPath, arg, it);
         } else if (arg == "--show-sdk-version" || arg == "-show-sdk-version") {
-            return libutil::Options::MarkBool(&_showSDKVersion, arg, it);
+            return libutil::Options::Current<bool>(&_showSDKVersion, arg, it);
         } else if (arg == "--show-sdk-build-version" || arg == "-show-sdk-build-version") {
-            return libutil::Options::MarkBool(&_showSDKBuildVersion, arg, it);
+            return libutil::Options::Current<bool>(&_showSDKBuildVersion, arg, it);
         } else if (arg == "--show-sdk-platform-path" || arg == "-show-sdk-platform-path") {
-            return libutil::Options::MarkBool(&_showSDKPlatformPath, arg, it);
+            return libutil::Options::Current<bool>(&_showSDKPlatformPath, arg, it);
         } else if (arg == "--show-sdk-platform-version" || arg == "-show-sdk-platform-version") {
-            return libutil::Options::MarkBool(&_showSDKPlatformVersion, arg, it);
+            return libutil::Options::Current<bool>(&_showSDKPlatformVersion, arg, it);
         } else if (arg == "-l" || arg == "--log" || arg == "-log") {
-            return libutil::Options::MarkBool(&_log, arg, it);
+            return libutil::Options::Current<bool>(&_log, arg, it);
         } else if (arg == "-v" || arg == "--verbose" || arg == "-verbose") {
-            return libutil::Options::MarkBool(&_verbose, arg, it);
+            return libutil::Options::Current<bool>(&_verbose, arg, it);
         } else if (arg == "-n" || arg == "--no-cache" || arg == "-no-cache") {
-            return libutil::Options::MarkBool(&_noCache, arg, it);
+            return libutil::Options::Current<bool>(&_noCache, arg, it);
         } else if (arg == "-k" || arg == "--kill-cache" || arg == "-kill-cache") {
-            return libutil::Options::MarkBool(&_killCache, arg, it);
+            return libutil::Options::Current<bool>(&_killCache, arg, it);
         } else if (arg == "--sdk" || arg == "-sdk") {
-            return libutil::Options::NextString(&_SDK, args, it);
+            return libutil::Options::Next<std::string>(&_SDK, args, it);
         } else if (arg == "--toolchain" || arg == "-toolchain") {
-            return libutil::Options::NextString(&_toolchain, args, it);
+            return libutil::Options::Next<std::string>(&_toolchain, args, it);
         } else if (arg == "--") {
-            return libutil::Options::MarkBool(&_separator, arg, it);
+            return libutil::Options::Current<bool>(&_separator, arg, it);
         }
     }
 
-    if (_separator || !_tool.empty() || (!arg.empty() && arg[0] != '-')) {
-        if (_tool.empty()) {
+    if (_separator || _tool || (!arg.empty() && arg[0] != '-')) {
+        if (!_tool) {
             _tool = arg;
             return std::make_pair(true, std::string());
         } else {
@@ -252,7 +238,7 @@ main(int argc, char **argv)
     /*
      * Handle the basic options that don't need SDKs.
      */
-    if (options.tool().empty()) {
+    if (!options.tool()) {
         if (options.help()) {
             return Help();
         } else if (options.version()) {
@@ -263,19 +249,16 @@ main(int argc, char **argv)
     /*
      * Parse fallback options from the environment.
      */
-    std::string toolchainsInput = options.toolchain();
-    if (toolchainsInput.empty()) {
+    ext::optional<std::string> toolchainsInput = options.toolchain();
+    if (!toolchainsInput) {
         if (char const *toolchains = getenv("TOOLCHAINS")) {
             toolchainsInput = std::string(toolchains);
         }
     }
-    std::string SDK = options.SDK();
-    if (SDK.empty()) {
+    ext::optional<std::string> SDK = options.SDK();
+    if (!SDK) {
         if (char const *sdkroot = getenv("SDKROOT")) {
             SDK = std::string(sdkroot);
-        } else {
-            /* Default SDK. */
-            SDK = "macosx";
         }
     }
     bool verbose = options.verbose() || getenv("xcrun_verbose") != NULL;
@@ -315,9 +298,13 @@ main(int argc, char **argv)
     /*
      * Determine the SDK to use.
      */
-    xcsdk::SDK::Target::shared_ptr target = manager->findTarget(SDK);
+    xcsdk::SDK::Target::shared_ptr target = manager->findTarget(SDK.value_or("macosx"));
     if (target == nullptr) {
-        fprintf(stderr, "error: unable to find sdk '%s'\n", SDK.c_str());
+        if (SDK) {
+            fprintf(stderr, "error: unable to find sdk '%s'\n", SDK->c_str());
+        } else {
+            fprintf(stderr, "error: unable to find default sdk\n");
+        }
         return -1;
     }
     if (verbose) {
@@ -328,9 +315,9 @@ main(int argc, char **argv)
      * Determine the toolchains to use. Default to the SDK's toolchains.
      */
     xcsdk::SDK::Toolchain::vector toolchains;
-    if (!toolchainsInput.empty()) {
+    if (toolchainsInput) {
         /* If the custom toolchain exists, use it instead. */
-        std::vector<std::string> toolchainTokens = pbxsetting::Type::ParseList(toolchainsInput);
+        std::vector<std::string> toolchainTokens = pbxsetting::Type::ParseList(*toolchainsInput);
         for (std::string const &toolchainToken : toolchainTokens) {
             if (auto TC = manager->findToolchain(toolchainToken)) {
                 toolchains.push_back(TC);
@@ -338,7 +325,7 @@ main(int argc, char **argv)
         }
 
         if (toolchains.empty()) {
-            fprintf(stderr, "error: unable to find toolchains in '%s'\n", toolchainsInput.c_str());
+            fprintf(stderr, "error: unable to find toolchains in '%s'\n", toolchainsInput->c_str());
             return -1;
         }
     } else {
@@ -388,7 +375,7 @@ main(int argc, char **argv)
             return -1;
         }
     } else {
-        if (options.tool().empty()) {
+        if (!options.tool()) {
             return Help("no tool provided");
         }
 
@@ -402,13 +389,13 @@ main(int argc, char **argv)
         /*
          * Find the tool to execute.
          */
-        ext::optional<std::string> executable = filesystem->findExecutable(options.tool(), executablePaths);
+        ext::optional<std::string> executable = filesystem->findExecutable(*options.tool(), executablePaths);
         if (!executable) {
-            fprintf(stderr, "error: tool '%s' not found\n", options.tool().c_str());
+            fprintf(stderr, "error: tool '%s' not found\n", options.tool()->c_str());
             return 1;
         }
         if (verbose) {
-            fprintf(stderr, "verbose: resolved tool '%s' to: %s\n", options.tool().c_str(), executable->c_str());
+            fprintf(stderr, "verbose: resolved tool '%s' to: %s\n", options.tool()->c_str(), executable->c_str());
         }
 
         if (options.find()) {
@@ -438,7 +425,7 @@ main(int argc, char **argv)
             }
             Subprocess process;
             if (!process.execute(*executable, options.args(), environment)) {
-                fprintf(stderr, "error: unable to execute tool '%s'\n", options.tool().c_str());
+                fprintf(stderr, "error: unable to execute tool '%s'\n", options.tool()->c_str());
                 return -1;
             }
 


### PR DESCRIPTION
Instead of checking if strings are empty, use optionals to store if
the arguments were passed at all. Additionally, add a few utility
methods to the option parser to simplify various tool option classes.