### PR TITLE
Minor cleanups for asset compilation.

### DIFF
--- a/Libraries/acdriver/CMakeLists.txt
+++ b/Libraries/acdriver/CMakeLists.txt
@@ -14,8 +14,8 @@ add_library(acdriver SHARED
             Sources/Result.cpp
             Sources/VersionAction.cpp
             Sources/CompileAction.cpp
-            Sources/CompileOutput.cpp
             Sources/Compile/Convert.cpp
+            Sources/Compile/Output.cpp
             Sources/Compile/AppIconSet.cpp
             Sources/Compile/BrandAssets.cpp
             Sources/Compile/ComplicationSet.cpp

--- a/Libraries/acdriver/CMakeLists.txt
+++ b/Libraries/acdriver/CMakeLists.txt
@@ -15,6 +15,7 @@ add_library(acdriver SHARED
             Sources/VersionAction.cpp
             Sources/CompileAction.cpp
             Sources/CompileOutput.cpp
+            Sources/Compile/Convert.cpp
             Sources/Compile/AppIconSet.cpp
             Sources/Compile/BrandAssets.cpp
             Sources/Compile/ComplicationSet.cpp

--- a/Libraries/acdriver/Headers/acdriver/Compile/AppIconSet.h
+++ b/Libraries/acdriver/Headers/acdriver/Compile/AppIconSet.h
@@ -19,10 +19,11 @@ namespace libutil { class Filesystem; }
 
 namespace acdriver {
 
-class CompileOutput;
 class Result;
 
 namespace Compile {
+
+class Output;
 
 class AppIconSet {
 private:
@@ -33,7 +34,7 @@ public:
     static bool Compile(
         std::shared_ptr<xcassets::Asset::AppIconSet> const &appIconSet,
         libutil::Filesystem *filesystem,
-        CompileOutput *compileOutput,
+        Output *compileOutput,
         Result *result);
 };
 

--- a/Libraries/acdriver/Headers/acdriver/Compile/BrandAssets.h
+++ b/Libraries/acdriver/Headers/acdriver/Compile/BrandAssets.h
@@ -19,10 +19,11 @@ namespace libutil { class Filesystem; }
 
 namespace acdriver {
 
-class CompileOutput;
 class Result;
 
 namespace Compile {
+
+class Output;
 
 class BrandAssets {
 private:
@@ -33,7 +34,7 @@ public:
     static bool Compile(
         std::shared_ptr<xcassets::Asset::BrandAssets> const &brandAssets,
         libutil::Filesystem *filesystem,
-        CompileOutput *compileOutput,
+        Output *compileOutput,
         Result *result);
 };
 

--- a/Libraries/acdriver/Headers/acdriver/Compile/ComplicationSet.h
+++ b/Libraries/acdriver/Headers/acdriver/Compile/ComplicationSet.h
@@ -19,10 +19,11 @@ namespace libutil { class Filesystem; }
 
 namespace acdriver {
 
-class CompileOutput;
 class Result;
 
 namespace Compile {
+
+class Output;
 
 class ComplicationSet {
 private:
@@ -33,7 +34,7 @@ public:
     static bool Compile(
         std::shared_ptr<xcassets::Asset::ComplicationSet> const &complicationSet,
         libutil::Filesystem *filesystem,
-        CompileOutput *compileOutput,
+        Output *compileOutput,
         Result *result);
 };
 

--- a/Libraries/acdriver/Headers/acdriver/Compile/Convert.h
+++ b/Libraries/acdriver/Headers/acdriver/Compile/Convert.h
@@ -1,0 +1,73 @@
+/**
+ Copyright (c) 2015-present, Facebook, Inc.
+ All rights reserved.
+
+ This source code is licensed under the BSD-style license found in the
+ LICENSE file in the root directory of this source tree. An additional grant
+ of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#ifndef __acdriver_Compile_Convert_h
+#define __acdriver_Compile_Convert_h
+
+#include <xcassets/Insets.h>
+#include <xcassets/Resizing.h>
+#include <xcassets/Slot/Idiom.h>
+#include <xcassets/Slot/Scale.h>
+#include <car/Rendition.h>
+#include <car/car_format.h>
+
+#include <string>
+#include <vector>
+
+namespace acdriver {
+namespace Compile {
+
+/*
+ * Convert various asset properties to a compiled form.
+ */
+class Convert {
+private:
+    Convert();
+    ~Convert();
+
+public:
+    /*
+     * The suffix for an image file name or plist key for an idiom.
+     */
+    static std::string IdiomSuffix(xcassets::Slot::Idiom idiom);
+
+    /*
+     * The suffix for an image file name for a specific scale.
+     */
+    static std::string ScaleSuffix(xcassets::Slot::Scale const &scale);
+
+public:
+    /*
+     * The archive attribute corresponding to an idiom.
+     */
+    static uint16_t IdiomAttribute(xcassets::Slot::Idiom idiom);
+
+    /*
+     * The rendition layout value for resizing information.
+     */
+    static enum car_rendition_value_layout
+    LayoutForResizingAndCenterMode(
+        xcassets::Resizing::Mode resizingMode,
+        xcassets::Resizing::Center::Mode centerMode);
+
+    /*
+     * The rendition slices for a resizing mode.
+     */
+    static std::vector<car::Rendition::Slice>
+    SlicesForResizingModeAndCapInsets(
+        uint32_t width,
+        uint32_t height,
+        xcassets::Resizing::Mode resizingMode,
+        ext::optional<xcassets::Insets> const &capInsets);
+};
+
+}
+}
+
+#endif // !__acdriver_Compile_Convert_h

--- a/Libraries/acdriver/Headers/acdriver/Compile/DataSet.h
+++ b/Libraries/acdriver/Headers/acdriver/Compile/DataSet.h
@@ -19,10 +19,11 @@ namespace libutil { class Filesystem; }
 
 namespace acdriver {
 
-class CompileOutput;
 class Result;
 
 namespace Compile {
+
+class Output;
 
 class DataSet {
 private:
@@ -33,7 +34,7 @@ public:
     static bool Compile(
         std::shared_ptr<xcassets::Asset::DataSet> const &dataSet,
         libutil::Filesystem *filesystem,
-        CompileOutput *compileOutput,
+        Output *compileOutput,
         Result *result);
 };
 

--- a/Libraries/acdriver/Headers/acdriver/Compile/GCDashboardImage.h
+++ b/Libraries/acdriver/Headers/acdriver/Compile/GCDashboardImage.h
@@ -19,10 +19,11 @@ namespace libutil { class Filesystem; }
 
 namespace acdriver {
 
-class CompileOutput;
 class Result;
 
 namespace Compile {
+
+class Output;
 
 class GCDashboardImage {
 private:
@@ -33,7 +34,7 @@ public:
     static bool Compile(
         std::shared_ptr<xcassets::Asset::GCDashboardImage> const &gcDashboardImage,
         libutil::Filesystem *filesystem,
-        CompileOutput *compileOutput,
+        Output *compileOutput,
         Result *result);
 };
 

--- a/Libraries/acdriver/Headers/acdriver/Compile/GCLeaderboard.h
+++ b/Libraries/acdriver/Headers/acdriver/Compile/GCLeaderboard.h
@@ -19,10 +19,11 @@ namespace libutil { class Filesystem; }
 
 namespace acdriver {
 
-class CompileOutput;
 class Result;
 
 namespace Compile {
+
+class Output;
 
 class GCLeaderboard {
 private:
@@ -33,7 +34,7 @@ public:
     static bool Compile(
         std::shared_ptr<xcassets::Asset::GCLeaderboard> const &gcLeaderboard,
         libutil::Filesystem *filesystem,
-        CompileOutput *compileOutput,
+        Output *compileOutput,
         Result *result);
 };
 

--- a/Libraries/acdriver/Headers/acdriver/Compile/GCLeaderboardSet.h
+++ b/Libraries/acdriver/Headers/acdriver/Compile/GCLeaderboardSet.h
@@ -19,10 +19,11 @@ namespace libutil { class Filesystem; }
 
 namespace acdriver {
 
-class CompileOutput;
 class Result;
 
 namespace Compile {
+
+class Output;
 
 class GCLeaderboardSet {
 private:
@@ -33,7 +34,7 @@ public:
     static bool Compile(
         std::shared_ptr<xcassets::Asset::GCLeaderboardSet> const &gcLeaderboardSet,
         libutil::Filesystem *filesystem,
-        CompileOutput *compileOutput,
+        Output *compileOutput,
         Result *result);
 };
 

--- a/Libraries/acdriver/Headers/acdriver/Compile/IconSet.h
+++ b/Libraries/acdriver/Headers/acdriver/Compile/IconSet.h
@@ -19,10 +19,11 @@ namespace libutil { class Filesystem; }
 
 namespace acdriver {
 
-class CompileOutput;
 class Result;
 
 namespace Compile {
+
+class Output;
 
 class IconSet {
 private:
@@ -33,7 +34,7 @@ public:
     static bool Compile(
         std::shared_ptr<xcassets::Asset::IconSet> const &iconSet,
         libutil::Filesystem *filesystem,
-        CompileOutput *compileOutput,
+        Output *compileOutput,
         Result *result);
 };
 

--- a/Libraries/acdriver/Headers/acdriver/Compile/ImageSet.h
+++ b/Libraries/acdriver/Headers/acdriver/Compile/ImageSet.h
@@ -19,10 +19,11 @@ namespace libutil { class Filesystem; }
 
 namespace acdriver {
 
-class CompileOutput;
 class Result;
 
 namespace Compile {
+
+class Output;
 
 class ImageSet {
 private:
@@ -33,14 +34,14 @@ public:
     static bool Compile(
         std::shared_ptr<xcassets::Asset::ImageSet> const &imageSet,
         libutil::Filesystem *filesystem,
-        CompileOutput *compileOutput,
+        Output *compileOutput,
         Result *result);
 
     static bool CompileAsset(
         std::shared_ptr<xcassets::Asset::ImageSet> const &imageSet,
         xcassets::Asset::ImageSet::Image const &image,
         libutil::Filesystem *filesystem,
-        CompileOutput *compileOutput,
+        Output *compileOutput,
         Result *result);
 };
 

--- a/Libraries/acdriver/Headers/acdriver/Compile/ImageStack.h
+++ b/Libraries/acdriver/Headers/acdriver/Compile/ImageStack.h
@@ -19,10 +19,11 @@ namespace libutil { class Filesystem; }
 
 namespace acdriver {
 
-class CompileOutput;
 class Result;
 
 namespace Compile {
+
+class Output;
 
 class ImageStack {
 private:
@@ -33,7 +34,7 @@ public:
     static bool Compile(
         std::shared_ptr<xcassets::Asset::ImageStack> const &imageStack,
         libutil::Filesystem *filesystem,
-        CompileOutput *compileOutput,
+        Output *compileOutput,
         Result *result);
 };
 

--- a/Libraries/acdriver/Headers/acdriver/Compile/ImageStackLayer.h
+++ b/Libraries/acdriver/Headers/acdriver/Compile/ImageStackLayer.h
@@ -19,10 +19,11 @@ namespace libutil { class Filesystem; }
 
 namespace acdriver {
 
-class CompileOutput;
 class Result;
 
 namespace Compile {
+
+class Output;
 
 class ImageStackLayer {
 private:
@@ -33,7 +34,7 @@ public:
     static bool Compile(
         std::shared_ptr<xcassets::Asset::ImageStackLayer> const &imageStackLayer,
         libutil::Filesystem *filesystem,
-        CompileOutput *compileOutput,
+        Output *compileOutput,
         Result *result);
 };
 

--- a/Libraries/acdriver/Headers/acdriver/Compile/LaunchImage.h
+++ b/Libraries/acdriver/Headers/acdriver/Compile/LaunchImage.h
@@ -19,10 +19,11 @@ namespace libutil { class Filesystem; }
 
 namespace acdriver {
 
-class CompileOutput;
 class Result;
 
 namespace Compile {
+
+class Output;
 
 class LaunchImage {
 private:
@@ -33,7 +34,7 @@ public:
     static bool Compile(
         std::shared_ptr<xcassets::Asset::LaunchImage> const &launchImage,
         libutil::Filesystem *filesystem,
-        CompileOutput *compileOutput,
+        Output *compileOutput,
         Result *result);
 };
 

--- a/Libraries/acdriver/Headers/acdriver/Compile/Output.h
+++ b/Libraries/acdriver/Headers/acdriver/Compile/Output.h
@@ -7,8 +7,8 @@
  of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#ifndef __acdriver_CompileOutput_h
-#define __acdriver_CompileOutput_h
+#ifndef __acdriver_Compile_Output_h
+#define __acdriver_Compile_Output_h
 
 #include <plist/Dictionary.h>
 #include <dependency/BinaryDependencyInfo.h>
@@ -28,10 +28,12 @@ namespace acdriver {
 class Options;
 class Result;
 
+namespace Compile {
+
 /*
  * Prints the contents of an asset catalog.
  */
-class CompileOutput {
+class Output {
 public:
     enum class Format {
         /*
@@ -57,7 +59,7 @@ private:
     dependency::BinaryDependencyInfo   _dependencyInfo;
 
 public:
-    CompileOutput(std::string const &root, Format format);
+    Output(std::string const &root, Format format);
 
 public:
     /*
@@ -124,5 +126,6 @@ public:
 };
 
 }
+}
 
-#endif // !__acdriver_CompileOutput_h
+#endif // !__acdriver_Compile_Output_h

--- a/Libraries/acdriver/Headers/acdriver/Compile/SpriteAtlas.h
+++ b/Libraries/acdriver/Headers/acdriver/Compile/SpriteAtlas.h
@@ -19,10 +19,11 @@ namespace libutil { class Filesystem; }
 
 namespace acdriver {
 
-class CompileOutput;
 class Result;
 
 namespace Compile {
+
+class Output;
 
 class SpriteAtlas {
 private:
@@ -33,7 +34,7 @@ public:
     static bool Compile(
         std::shared_ptr<xcassets::Asset::SpriteAtlas> const &spriteAtlas,
         libutil::Filesystem *filesystem,
-        CompileOutput *compileOutput,
+        Output *compileOutput,
         Result *result);
 };
 

--- a/Libraries/acdriver/Sources/Compile/AppIconSet.cpp
+++ b/Libraries/acdriver/Sources/Compile/AppIconSet.cpp
@@ -9,7 +9,7 @@
 
 #include <acdriver/Compile/AppIconSet.h>
 #include <acdriver/Compile/Convert.h>
-#include <acdriver/CompileOutput.h>
+#include <acdriver/Compile/Output.h>
 #include <acdriver/Result.h>
 #include <plist/Array.h>
 #include <plist/Boolean.h>
@@ -21,7 +21,7 @@
 
 using acdriver::Compile::AppIconSet;
 using acdriver::Compile::Convert;
-using acdriver::CompileOutput;
+using acdriver::Compile::Output;
 using acdriver::Result;
 using libutil::Filesystem;
 
@@ -51,7 +51,7 @@ bool AppIconSet::
 Compile(
     std::shared_ptr<xcassets::Asset::AppIconSet> const &appIconSet,
     Filesystem *filesystem,
-    CompileOutput *compileOutput,
+    Output *compileOutput,
     Result *result)
 {
     struct IdiomHash
@@ -75,7 +75,7 @@ Compile(
                 result->document(
                     Result::Severity::Warning,
                     appIconSet->path(),
-                    { CompileOutput::AssetReference(appIconSet) },
+                    { Output::AssetReference(appIconSet) },
                     "Ambiguous Content",
                     "an icon in \"" + appIconSet->name().name() + "\" is unassigned");
                 continue;

--- a/Libraries/acdriver/Sources/Compile/BrandAssets.cpp
+++ b/Libraries/acdriver/Sources/Compile/BrandAssets.cpp
@@ -8,12 +8,12 @@
  */
 
 #include <acdriver/Compile/BrandAssets.h>
-#include <acdriver/CompileOutput.h>
+#include <acdriver/Compile/Output.h>
 #include <acdriver/Result.h>
 #include <libutil/Filesystem.h>
 
 using acdriver::Compile::BrandAssets;
-using acdriver::CompileOutput;
+using acdriver::Compile::Output;
 using acdriver::Result;
 using libutil::Filesystem;
 
@@ -21,13 +21,13 @@ bool BrandAssets::
 Compile(
     std::shared_ptr<xcassets::Asset::BrandAssets> const &brandAssets,
     Filesystem *filesystem,
-    CompileOutput *compileOutput,
+    Output *compileOutput,
     Result *result)
 {
     result->document(
         Result::Severity::Warning,
         brandAssets->path(),
-        { CompileOutput::AssetReference(brandAssets) },
+        { Output::AssetReference(brandAssets) },
         "Not Implemented",
         "brand assets not yet supported");
 

--- a/Libraries/acdriver/Sources/Compile/ComplicationSet.cpp
+++ b/Libraries/acdriver/Sources/Compile/ComplicationSet.cpp
@@ -8,12 +8,12 @@
  */
 
 #include <acdriver/Compile/ComplicationSet.h>
-#include <acdriver/CompileOutput.h>
+#include <acdriver/Compile/Output.h>
 #include <acdriver/Result.h>
 #include <libutil/Filesystem.h>
 
 using acdriver::Compile::ComplicationSet;
-using acdriver::CompileOutput;
+using acdriver::Compile::Output;
 using acdriver::Result;
 using libutil::Filesystem;
 
@@ -21,13 +21,13 @@ bool ComplicationSet::
 Compile(
     std::shared_ptr<xcassets::Asset::ComplicationSet> const &complicationSet,
     Filesystem *filesystem,
-    CompileOutput *compileOutput,
+    Output *compileOutput,
     Result *result)
 {
     result->document(
         Result::Severity::Warning,
         complicationSet->path(),
-        { CompileOutput::AssetReference(complicationSet) },
+        { Output::AssetReference(complicationSet) },
         "Not Implemented",
         "complication set not yet supported");
 

--- a/Libraries/acdriver/Sources/Compile/Convert.cpp
+++ b/Libraries/acdriver/Sources/Compile/Convert.cpp
@@ -1,0 +1,168 @@
+/**
+ Copyright (c) 2015-present, Facebook, Inc.
+ All rights reserved.
+
+ This source code is licensed under the BSD-style license found in the
+ LICENSE file in the root directory of this source tree. An additional grant
+ of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#include <acdriver/Compile/Convert.h>
+
+#include <sstream>
+
+using acdriver::Compile::Convert;
+
+std::string Convert::
+IdiomSuffix(xcassets::Slot::Idiom idiom)
+{
+    switch (idiom) {
+        case xcassets::Slot::Idiom::Universal:
+            return std::string();
+        case xcassets::Slot::Idiom::Phone:
+            return std::string();
+        case xcassets::Slot::Idiom::Pad:
+            return "~ipad";
+        case xcassets::Slot::Idiom::Desktop:
+            // TODO: no idiom suffix for desktop
+            return std::string();
+        case xcassets::Slot::Idiom::TV:
+            return "~tv";
+        case xcassets::Slot::Idiom::Watch:
+            return "~watch";
+        case xcassets::Slot::Idiom::Car:
+            return "~car";
+    }
+
+    abort();
+}
+
+std::string Convert::
+ScaleSuffix(xcassets::Slot::Scale const &scale)
+{
+    if (scale.value() != 1.0) {
+        std::ostringstream out;
+        out << "@";
+        out << scale.value();
+        out << "x";
+        return out.str();
+    }
+
+    return std::string();
+}
+
+uint16_t Convert::
+IdiomAttribute(xcassets::Slot::Idiom idiom)
+{
+    switch (idiom) {
+        case xcassets::Slot::Idiom::Universal:
+            return car_attribute_identifier_idiom_value_universal;
+            break;
+        case xcassets::Slot::Idiom::Phone:
+            return car_attribute_identifier_idiom_value_phone;
+            break;
+        case xcassets::Slot::Idiom::Pad:
+            return car_attribute_identifier_idiom_value_pad;
+            break;
+        case xcassets::Slot::Idiom::Desktop:
+            // TODO: desktop has no idiom value
+            return car_attribute_identifier_idiom_value_universal;
+        case xcassets::Slot::Idiom::TV:
+            return car_attribute_identifier_idiom_value_tv;
+        case xcassets::Slot::Idiom::Watch:
+            return car_attribute_identifier_idiom_value_watch;
+        case xcassets::Slot::Idiom::Car:
+            return car_attribute_identifier_idiom_value_car;
+        default:
+            return car_attribute_identifier_idiom_value_universal;
+    }
+}
+
+enum car_rendition_value_layout Convert::
+LayoutForResizingAndCenterMode(xcassets::Resizing::Mode resizingMode, xcassets::Resizing::Center::Mode centerMode)
+{
+    switch (resizingMode) {
+        case xcassets::Resizing::Mode::ThreePartHorizontal:
+            switch (centerMode) {
+                case xcassets::Resizing::Center::Mode::Tile:
+                    return car_rendition_value_layout_three_part_horizontal_tile;
+                case xcassets::Resizing::Center::Mode::Stretch:
+                    return car_rendition_value_layout_three_part_horizontal_scale;
+                default:
+                    return car_rendition_value_layout_three_part_horizontal_tile;
+            }
+        case xcassets::Resizing::Mode::ThreePartVertical:
+            switch (centerMode) {
+                case xcassets::Resizing::Center::Mode::Tile:
+                    return car_rendition_value_layout_three_part_vertical_tile;
+                case xcassets::Resizing::Center::Mode::Stretch:
+                    return car_rendition_value_layout_three_part_vertical_scale;
+                default:
+                    return car_rendition_value_layout_three_part_vertical_tile;
+            }
+        case xcassets::Resizing::Mode::NinePart:
+            switch (centerMode) {
+                case xcassets::Resizing::Center::Mode::Tile:
+                    return car_rendition_value_layout_nine_part_tile;
+                case xcassets::Resizing::Center::Mode::Stretch:
+                    return car_rendition_value_layout_nine_part_scale;
+                default:
+                    return car_rendition_value_layout_nine_part_tile;
+            }
+        default: abort();
+    }
+}
+
+std::vector<car::Rendition::Slice> Convert::
+SlicesForResizingModeAndCapInsets(uint32_t width, uint32_t height, xcassets::Resizing::Mode resizingMode, ext::optional<xcassets::Insets> const &capInsets)
+{
+    double topCapInset = capInsets ? capInsets->top().value_or(0) : 0;
+    double leftCapInset = capInsets ? capInsets->left().value_or(0) : 0;
+    double bottomCapInset = capInsets ? capInsets->bottom().value_or(0) : 0;
+    double rightCapInset = capInsets ? capInsets->right().value_or(0) : 0;
+
+    uint32_t leftWidth = static_cast<uint32_t>(leftCapInset);
+    uint32_t centerWidth = static_cast<uint32_t>(width - (leftCapInset + rightCapInset));
+    uint32_t rightWidth = static_cast<uint32_t>(rightCapInset);
+
+    uint32_t topHeight = static_cast<uint32_t>(topCapInset);
+    uint32_t centerHeight = static_cast<uint32_t>(height - (topCapInset + bottomCapInset));
+    uint32_t bottomHeight = static_cast<uint32_t>(bottomCapInset);
+
+    uint32_t topVerticalOffset = static_cast<uint32_t>(height - topCapInset);
+    uint32_t centerVerticalOffset = static_cast<uint32_t>(bottomCapInset);
+    uint32_t bottomVerticalOffset = static_cast<uint32_t>(0);
+
+    uint32_t leftHorizontalOffset = static_cast<uint32_t>(0);
+    uint32_t centerHorizontalOffset = static_cast<uint32_t>(leftCapInset);
+    uint32_t rightHorizontalOffset = static_cast<uint32_t>(width - rightCapInset);
+
+    switch (resizingMode) {
+        case xcassets::Resizing::Mode::ThreePartHorizontal:
+            return {
+                { leftHorizontalOffset,   0, leftWidth,   height },
+                { centerHorizontalOffset, 0, centerWidth, height },
+                { rightHorizontalOffset,  0, rightWidth,  height },
+            };
+        case xcassets::Resizing::Mode::ThreePartVertical:
+            return {
+                { 0, topVerticalOffset,    width, topHeight    },
+                { 0, centerVerticalOffset, width, centerHeight },
+                { 0, bottomVerticalOffset, width, bottomHeight },
+            };
+        case xcassets::Resizing::Mode::NinePart:
+            return {
+                { leftHorizontalOffset,   topVerticalOffset,    leftWidth,   topHeight    },
+                { centerHorizontalOffset, topVerticalOffset,    centerWidth, topHeight    },
+                { rightHorizontalOffset,  topVerticalOffset,    rightWidth,  topHeight    },
+                { leftHorizontalOffset,   centerVerticalOffset, leftWidth,   centerHeight },
+                { centerHorizontalOffset, centerVerticalOffset, centerWidth, centerHeight },
+                { rightHorizontalOffset,  centerVerticalOffset, rightWidth,  centerHeight },
+                { leftHorizontalOffset,   bottomVerticalOffset, leftWidth,   bottomHeight },
+                { centerHorizontalOffset, bottomVerticalOffset, centerWidth, bottomHeight },
+                { rightHorizontalOffset,  bottomVerticalOffset, rightWidth,  bottomHeight },
+            };
+        default: abort();
+    }
+}
+

--- a/Libraries/acdriver/Sources/Compile/DataSet.cpp
+++ b/Libraries/acdriver/Sources/Compile/DataSet.cpp
@@ -8,12 +8,12 @@
  */
 
 #include <acdriver/Compile/DataSet.h>
-#include <acdriver/CompileOutput.h>
+#include <acdriver/Compile/Output.h>
 #include <acdriver/Result.h>
 #include <libutil/Filesystem.h>
 
 using acdriver::Compile::DataSet;
-using acdriver::CompileOutput;
+using acdriver::Compile::Output;
 using acdriver::Result;
 using libutil::Filesystem;
 
@@ -21,13 +21,13 @@ bool DataSet::
 Compile(
     std::shared_ptr<xcassets::Asset::DataSet> const &dataSet,
     Filesystem *filesystem,
-    CompileOutput *compileOutput,
+    Output *compileOutput,
     Result *result)
 {
     result->document(
         Result::Severity::Warning,
         dataSet->path(),
-        { CompileOutput::AssetReference(dataSet) },
+        { Output::AssetReference(dataSet) },
         "Not Implemented",
         "data set not yet supported");
 

--- a/Libraries/acdriver/Sources/Compile/GCDashboardImage.cpp
+++ b/Libraries/acdriver/Sources/Compile/GCDashboardImage.cpp
@@ -8,12 +8,12 @@
  */
 
 #include <acdriver/Compile/GCDashboardImage.h>
-#include <acdriver/CompileOutput.h>
+#include <acdriver/Compile/Output.h>
 #include <acdriver/Result.h>
 #include <libutil/Filesystem.h>
 
 using acdriver::Compile::GCDashboardImage;
-using acdriver::CompileOutput;
+using acdriver::Compile::Output;
 using acdriver::Result;
 using libutil::Filesystem;
 
@@ -21,13 +21,13 @@ bool GCDashboardImage::
 Compile(
     std::shared_ptr<xcassets::Asset::GCDashboardImage> const &gcDashboardImage,
     Filesystem *filesystem,
-    CompileOutput *compileOutput,
+    Output *compileOutput,
     Result *result)
 {
     result->document(
         Result::Severity::Warning,
         gcDashboardImage->path(),
-        { CompileOutput::AssetReference(gcDashboardImage) },
+        { Output::AssetReference(gcDashboardImage) },
         "Not Implemented",
         "gc dashboard image not yet supported");
 

--- a/Libraries/acdriver/Sources/Compile/GCLeaderboard.cpp
+++ b/Libraries/acdriver/Sources/Compile/GCLeaderboard.cpp
@@ -8,12 +8,12 @@
  */
 
 #include <acdriver/Compile/GCLeaderboard.h>
-#include <acdriver/CompileOutput.h>
+#include <acdriver/Compile/Output.h>
 #include <acdriver/Result.h>
 #include <libutil/Filesystem.h>
 
 using acdriver::Compile::GCLeaderboard;
-using acdriver::CompileOutput;
+using acdriver::Compile::Output;
 using acdriver::Result;
 using libutil::Filesystem;
 
@@ -21,13 +21,13 @@ bool GCLeaderboard::
 Compile(
     std::shared_ptr<xcassets::Asset::GCLeaderboard> const &gcLeaderboard,
     Filesystem *filesystem,
-    CompileOutput *compileOutput,
+    Output *compileOutput,
     Result *result)
 {
     result->document(
         Result::Severity::Warning,
         gcLeaderboard->path(),
-        { CompileOutput::AssetReference(gcLeaderboard) },
+        { Output::AssetReference(gcLeaderboard) },
         "Not Implemented",
         "gc leaderboard not yet supported");
 

--- a/Libraries/acdriver/Sources/Compile/GCLeaderboardSet.cpp
+++ b/Libraries/acdriver/Sources/Compile/GCLeaderboardSet.cpp
@@ -8,12 +8,12 @@
  */
 
 #include <acdriver/Compile/GCLeaderboardSet.h>
-#include <acdriver/CompileOutput.h>
+#include <acdriver/Compile/Output.h>
 #include <acdriver/Result.h>
 #include <libutil/Filesystem.h>
 
 using acdriver::Compile::GCLeaderboardSet;
-using acdriver::CompileOutput;
+using acdriver::Compile::Output;
 using acdriver::Result;
 using libutil::Filesystem;
 
@@ -21,13 +21,13 @@ bool GCLeaderboardSet::
 Compile(
     std::shared_ptr<xcassets::Asset::GCLeaderboardSet> const &gcComplicationSet,
     Filesystem *filesystem,
-    CompileOutput *compileOutput,
+    Output *compileOutput,
     Result *result)
 {
     result->document(
         Result::Severity::Warning,
         gcComplicationSet->path(),
-        { CompileOutput::AssetReference(gcComplicationSet) },
+        { Output::AssetReference(gcComplicationSet) },
         "Not Implemented",
         "gc leaderboard set yet supported");
 

--- a/Libraries/acdriver/Sources/Compile/IconSet.cpp
+++ b/Libraries/acdriver/Sources/Compile/IconSet.cpp
@@ -8,12 +8,12 @@
  */
 
 #include <acdriver/Compile/IconSet.h>
-#include <acdriver/CompileOutput.h>
+#include <acdriver/Compile/Output.h>
 #include <acdriver/Result.h>
 #include <libutil/Filesystem.h>
 
 using acdriver::Compile::IconSet;
-using acdriver::CompileOutput;
+using acdriver::Compile::Output;
 using acdriver::Result;
 using libutil::Filesystem;
 
@@ -21,13 +21,13 @@ bool IconSet::
 Compile(
     std::shared_ptr<xcassets::Asset::IconSet> const &iconSet,
     Filesystem *filesystem,
-    CompileOutput *compileOutput,
+    Output *compileOutput,
     Result *result)
 {
     result->document(
         Result::Severity::Warning,
         iconSet->path(),
-        { CompileOutput::AssetReference(iconSet) },
+        { Output::AssetReference(iconSet) },
         "Not Implemented",
         "icon set not yet supported");
 

--- a/Libraries/acdriver/Sources/Compile/ImageSet.cpp
+++ b/Libraries/acdriver/Sources/Compile/ImageSet.cpp
@@ -9,7 +9,7 @@
 
 #include <acdriver/Compile/ImageSet.h>
 #include <acdriver/Compile/Convert.h>
-#include <acdriver/CompileOutput.h>
+#include <acdriver/Compile/Output.h>
 #include <acdriver/Result.h>
 #include <graphics/PixelFormat.h>
 #include <graphics/Format/PNG.h>
@@ -28,7 +28,7 @@
 
 using acdriver::Compile::ImageSet;
 using acdriver::Compile::Convert;
-using acdriver::CompileOutput;
+using acdriver::Compile::Output;
 using acdriver::Result;
 using libutil::Filesystem;
 using libutil::FSUtil;
@@ -37,7 +37,7 @@ bool ImageSet::
 Compile(
     std::shared_ptr<xcassets::Asset::ImageSet> const &imageSet,
     Filesystem *filesystem,
-    CompileOutput *compileOutput,
+    Output *compileOutput,
     Result *result)
 {
     bool success = true;
@@ -65,7 +65,7 @@ CompileAsset(
     std::shared_ptr<xcassets::Asset::ImageSet> const &imageSet,
     xcassets::Asset::ImageSet::Image const &image,
     Filesystem *filesystem,
-    CompileOutput *compileOutput,
+    Output *compileOutput,
     Result *result)
 {
     static std::map<std::string, uint16_t> idMap = {};

--- a/Libraries/acdriver/Sources/Compile/ImageStack.cpp
+++ b/Libraries/acdriver/Sources/Compile/ImageStack.cpp
@@ -8,12 +8,12 @@
  */
 
 #include <acdriver/Compile/ImageStack.h>
-#include <acdriver/CompileOutput.h>
+#include <acdriver/Compile/Output.h>
 #include <acdriver/Result.h>
 #include <libutil/Filesystem.h>
 
 using acdriver::Compile::ImageStack;
-using acdriver::CompileOutput;
+using acdriver::Compile::Output;
 using acdriver::Result;
 using libutil::Filesystem;
 
@@ -21,13 +21,13 @@ bool ImageStack::
 Compile(
     std::shared_ptr<xcassets::Asset::ImageStack> const &imageStack,
     Filesystem *filesystem,
-    CompileOutput *compileOutput,
+    Output *compileOutput,
     Result *result)
 {
     result->document(
         Result::Severity::Warning,
         imageStack->path(),
-        { CompileOutput::AssetReference(imageStack) },
+        { Output::AssetReference(imageStack) },
         "Not Implemented",
         "image stack not yet supported");
 

--- a/Libraries/acdriver/Sources/Compile/ImageStackLayer.cpp
+++ b/Libraries/acdriver/Sources/Compile/ImageStackLayer.cpp
@@ -8,12 +8,12 @@
  */
 
 #include <acdriver/Compile/ImageStackLayer.h>
-#include <acdriver/CompileOutput.h>
+#include <acdriver/Compile/Output.h>
 #include <acdriver/Result.h>
 #include <libutil/Filesystem.h>
 
 using acdriver::Compile::ImageStackLayer;
-using acdriver::CompileOutput;
+using acdriver::Compile::Output;
 using acdriver::Result;
 using libutil::Filesystem;
 
@@ -21,13 +21,13 @@ bool ImageStackLayer::
 Compile(
     std::shared_ptr<xcassets::Asset::ImageStackLayer> const &imageStackLayer,
     Filesystem *filesystem,
-    CompileOutput *compileOutput,
+    Output *compileOutput,
     Result *result)
 {
     result->document(
         Result::Severity::Warning,
         imageStackLayer->path(),
-        { CompileOutput::AssetReference(imageStackLayer) },
+        { Output::AssetReference(imageStackLayer) },
         "Not Implemented",
         "image stack layer not yet supported");
 

--- a/Libraries/acdriver/Sources/Compile/LaunchImage.cpp
+++ b/Libraries/acdriver/Sources/Compile/LaunchImage.cpp
@@ -8,12 +8,12 @@
  */
 
 #include <acdriver/Compile/LaunchImage.h>
-#include <acdriver/CompileOutput.h>
+#include <acdriver/Compile/Output.h>
 #include <acdriver/Result.h>
 #include <libutil/Filesystem.h>
 
 using acdriver::Compile::LaunchImage;
-using acdriver::CompileOutput;
+using acdriver::Compile::Output;
 using acdriver::Result;
 using libutil::Filesystem;
 
@@ -21,13 +21,13 @@ bool LaunchImage::
 Compile(
     std::shared_ptr<xcassets::Asset::LaunchImage> const &launchImage,
     Filesystem *filesystem,
-    CompileOutput *compileOutput,
+    Output *compileOutput,
     Result *result)
 {
     result->document(
         Result::Severity::Warning,
         launchImage->path(),
-        { CompileOutput::AssetReference(launchImage) },
+        { Output::AssetReference(launchImage) },
         "Not Implemented",
         "launch image not yet supported");
 

--- a/Libraries/acdriver/Sources/Compile/Output.cpp
+++ b/Libraries/acdriver/Sources/Compile/Output.cpp
@@ -7,7 +7,7 @@
  of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#include <acdriver/CompileOutput.h>
+#include <acdriver/Compile/Output.h>
 #include <acdriver/Options.h>
 #include <acdriver/Result.h>
 #include <xcassets/Asset/Asset.h>
@@ -15,20 +15,20 @@
 #include <plist/Format/Format.h>
 #include <plist/Format/XML.h>
 
-using acdriver::CompileOutput;
+using acdriver::Compile::Output;
 using acdriver::Options;
 using acdriver::Result;
 using libutil::Filesystem;
 
-CompileOutput::
-CompileOutput(std::string const &root, Format format) :
+Output::
+Output(std::string const &root, Format format) :
     _root          (root),
     _format        (format),
     _additionalInfo(plist::Dictionary::New())
 {
 }
 
-bool CompileOutput::
+bool Output::
 write(Filesystem *filesystem, ext::optional<std::string> const &partialInfoPlist, ext::optional<std::string> const &dependencyInfo, Result *result) const
 {
     bool success = true;
@@ -90,7 +90,7 @@ write(Filesystem *filesystem, ext::optional<std::string> const &partialInfoPlist
     return success;
 }
 
-std::string CompileOutput::
+std::string Output::
 AssetReference(std::shared_ptr<xcassets::Asset::Asset> const &asset)
 {
     // TODO: include [] for each key

--- a/Libraries/acdriver/Sources/Compile/SpriteAtlas.cpp
+++ b/Libraries/acdriver/Sources/Compile/SpriteAtlas.cpp
@@ -8,12 +8,12 @@
  */
 
 #include <acdriver/Compile/SpriteAtlas.h>
-#include <acdriver/CompileOutput.h>
+#include <acdriver/Compile/Output.h>
 #include <acdriver/Result.h>
 #include <libutil/Filesystem.h>
 
 using acdriver::Compile::SpriteAtlas;
-using acdriver::CompileOutput;
+using acdriver::Compile::Output;
 using acdriver::Result;
 using libutil::Filesystem;
 
@@ -21,13 +21,13 @@ bool SpriteAtlas::
 Compile(
     std::shared_ptr<xcassets::Asset::SpriteAtlas> const &spriteAtlas,
     Filesystem *filesystem,
-    CompileOutput *compileOutput,
+    Output *compileOutput,
     Result *result)
 {
     result->document(
         Result::Severity::Warning,
         spriteAtlas->path(),
-        { CompileOutput::AssetReference(spriteAtlas) },
+        { Output::AssetReference(spriteAtlas) },
         "Not Implemented",
         "sprite atlas yet supported");
 

--- a/Libraries/acdriver/Sources/CompileAction.cpp
+++ b/Libraries/acdriver/Sources/CompileAction.cpp
@@ -8,6 +8,7 @@
  */
 
 #include <acdriver/CompileAction.h>
+#include <acdriver/Compile/Output.h>
 #include <acdriver/Compile/AppIconSet.h>
 #include <acdriver/Compile/BrandAssets.h>
 #include <acdriver/Compile/ComplicationSet.h>
@@ -21,7 +22,6 @@
 #include <acdriver/Compile/ImageStackLayer.h>
 #include <acdriver/Compile/LaunchImage.h>
 #include <acdriver/Compile/SpriteAtlas.h>
-#include <acdriver/CompileOutput.h>
 #include <acdriver/Options.h>
 #include <acdriver/Output.h>
 #include <acdriver/Result.h>
@@ -40,20 +40,7 @@
 #include <plist/String.h>
 
 using acdriver::CompileAction;
-using acdriver::CompileOutput;
-using acdriver::Compile::AppIconSet;
-using acdriver::Compile::BrandAssets;
-using acdriver::Compile::ComplicationSet;
-using acdriver::Compile::GCDashboardImage;
-using acdriver::Compile::GCLeaderboard;
-using acdriver::Compile::GCLeaderboardSet;
-using acdriver::Compile::DataSet;
-using acdriver::Compile::IconSet;
-using acdriver::Compile::ImageSet;
-using acdriver::Compile::ImageStack;
-using acdriver::Compile::ImageStackLayer;
-using acdriver::Compile::LaunchImage;
-using acdriver::Compile::SpriteAtlas;
+namespace Compile = acdriver::Compile;
 using acdriver::Options;
 using acdriver::Output;
 using acdriver::Result;
@@ -76,7 +63,7 @@ CompileAsset(
     std::shared_ptr<xcassets::Asset::Asset> const &parent,
     Filesystem *filesystem,
     Options const &options,
-    CompileOutput *compileOutput,
+    Compile::Output *compileOutput,
     Result *result);
 
 template<typename T>
@@ -86,7 +73,7 @@ CompileChildren(
     std::shared_ptr<xcassets::Asset::Asset> const &parent,
     Filesystem *filesystem,
     Options const &options,
-    CompileOutput *compileOutput,
+    Compile::Output *compileOutput,
     Result *result)
 {
     bool success = true;
@@ -106,7 +93,7 @@ CompileAsset(
     std::shared_ptr<xcassets::Asset::Asset> const &parent,
     Filesystem *filesystem,
     Options const &options,
-    CompileOutput *compileOutput,
+    Compile::Output *compileOutput,
     Result *result)
 {
     std::string filename = FSUtil::GetBaseName(asset->path());
@@ -115,13 +102,13 @@ CompileAsset(
         case xcassets::Asset::AssetType::AppIconSet: {
             auto appIconSet = std::static_pointer_cast<xcassets::Asset::AppIconSet>(asset);
             if (appIconSet->name().name() == options.appIcon()) {
-                AppIconSet::Compile(appIconSet, filesystem, compileOutput, result);
+                Compile::AppIconSet::Compile(appIconSet, filesystem, compileOutput, result);
             }
             break;
         }
         case xcassets::Asset::AssetType::BrandAssets: {
             auto brandAssets = std::static_pointer_cast<xcassets::Asset::BrandAssets>(asset);
-            BrandAssets::Compile(brandAssets, filesystem, compileOutput, result);
+            Compile::BrandAssets::Compile(brandAssets, filesystem, compileOutput, result);
             CompileChildren(brandAssets->children(), asset, filesystem, options, compileOutput, result);
             break;
         }
@@ -132,30 +119,30 @@ CompileAsset(
         }
         case xcassets::Asset::AssetType::ComplicationSet: {
             auto complicationSet = std::static_pointer_cast<xcassets::Asset::ComplicationSet>(asset);
-            ComplicationSet::Compile(complicationSet, filesystem, compileOutput, result);
+            Compile::ComplicationSet::Compile(complicationSet, filesystem, compileOutput, result);
             CompileChildren(complicationSet->children(), asset, filesystem, options, compileOutput, result);
             break;
         }
         case xcassets::Asset::AssetType::DataSet: {
             auto dataSet = std::static_pointer_cast<xcassets::Asset::DataSet>(asset);
-            DataSet::Compile(dataSet, filesystem, compileOutput, result);
+            Compile::DataSet::Compile(dataSet, filesystem, compileOutput, result);
             break;
         }
         case xcassets::Asset::AssetType::GCDashboardImage: {
             auto dashboardImage = std::static_pointer_cast<xcassets::Asset::GCDashboardImage>(asset);
-            GCDashboardImage::Compile(dashboardImage, filesystem, compileOutput, result);
+            Compile::GCDashboardImage::Compile(dashboardImage, filesystem, compileOutput, result);
             CompileChildren(dashboardImage->children(), asset, filesystem, options, compileOutput, result);
             break;
         }
         case xcassets::Asset::AssetType::GCLeaderboard: {
             auto leaderboard = std::static_pointer_cast<xcassets::Asset::GCLeaderboard>(asset);
-            GCLeaderboard::Compile(leaderboard, filesystem, compileOutput, result);
+            Compile::GCLeaderboard::Compile(leaderboard, filesystem, compileOutput, result);
             CompileChildren(leaderboard->children(), asset, filesystem, options, compileOutput, result);
             break;
         }
         case xcassets::Asset::AssetType::GCLeaderboardSet: {
             auto leaderboardSet = std::static_pointer_cast<xcassets::Asset::GCLeaderboardSet>(asset);
-            GCLeaderboardSet::Compile(leaderboardSet, filesystem, compileOutput, result);
+            Compile::GCLeaderboardSet::Compile(leaderboardSet, filesystem, compileOutput, result);
             CompileChildren(leaderboardSet->children(), asset, filesystem, options, compileOutput, result);
             break;
         }
@@ -166,36 +153,36 @@ CompileAsset(
         }
         case xcassets::Asset::AssetType::IconSet: {
             auto iconSet = std::static_pointer_cast<xcassets::Asset::IconSet>(asset);
-            IconSet::Compile(iconSet, filesystem, compileOutput, result);
+            Compile::IconSet::Compile(iconSet, filesystem, compileOutput, result);
             break;
         }
         case xcassets::Asset::AssetType::ImageSet: {
             auto imageSet = std::static_pointer_cast<xcassets::Asset::ImageSet>(asset);
-            ImageSet::Compile(imageSet, filesystem, compileOutput, result);
+            Compile::ImageSet::Compile(imageSet, filesystem, compileOutput, result);
             break;
         }
         case xcassets::Asset::AssetType::ImageStack: {
             auto imageStack = std::static_pointer_cast<xcassets::Asset::ImageStack>(asset);
-            ImageStack::Compile(imageStack, filesystem, compileOutput, result);
+            Compile::ImageStack::Compile(imageStack, filesystem, compileOutput, result);
             CompileChildren(imageStack->children(), asset, filesystem, options, compileOutput, result);
             break;
         }
         case xcassets::Asset::AssetType::ImageStackLayer: {
             auto imageStackLayer = std::static_pointer_cast<xcassets::Asset::ImageStackLayer>(asset);
-            ImageStackLayer::Compile(imageStackLayer, filesystem, compileOutput, result);
+            Compile::ImageStackLayer::Compile(imageStackLayer, filesystem, compileOutput, result);
             // TODO: CompileChildren(imageStackLayer->children(), asset, filesystem, options, compileOutput, result);
             break;
         }
         case xcassets::Asset::AssetType::LaunchImage: {
             auto launchImage = std::static_pointer_cast<xcassets::Asset::LaunchImage>(asset);
             if (launchImage->name().name() == options.launchImage()) {
-                LaunchImage::Compile(launchImage, filesystem, compileOutput, result);
+                Compile::LaunchImage::Compile(launchImage, filesystem, compileOutput, result);
             }
             break;
         }
         case xcassets::Asset::AssetType::SpriteAtlas: {
             auto spriteAtlas = std::static_pointer_cast<xcassets::Asset::SpriteAtlas>(asset);
-            SpriteAtlas::Compile(spriteAtlas, filesystem, compileOutput, result);
+            Compile::SpriteAtlas::Compile(spriteAtlas, filesystem, compileOutput, result);
             CompileChildren(spriteAtlas->children(), asset, filesystem, options, compileOutput, result);
             break;
         }
@@ -204,14 +191,14 @@ CompileAsset(
     return true;
 }
 
-static ext::optional<CompileOutput::Format>
+static ext::optional<Compile::Output::Format>
 DetermineOutputFormat(std::string const &minimumDeploymentTarget)
 {
     if (!minimumDeploymentTarget.empty()) {
         // TODO: if < 7, use Folder output format
     }
 
-    return CompileOutput::Format::Compiled;
+    return Compile::Output::Format::Compiled;
 }
 
 void CompileAction::
@@ -220,18 +207,18 @@ run(Filesystem *filesystem, Options const &options, Output *output, Result *resu
     /*
      * Determine format to output compiled assets.
      */
-    ext::optional<CompileOutput::Format> outputFormat = DetermineOutputFormat(options.minimumDeploymentTarget());
+    ext::optional<Compile::Output::Format> outputFormat = DetermineOutputFormat(options.minimumDeploymentTarget());
     if (!outputFormat) {
         result->normal(Result::Severity::Error, "invalid minimum deployment target");
         return;
     }
 
-    CompileOutput compileOutput = CompileOutput(options.compile(), *outputFormat);
+    Compile::Output compileOutput = Compile::Output(options.compile(), *outputFormat);
 
     /*
      * If necssary, create output archive to write into.
      */
-    if (compileOutput.format() == CompileOutput::Format::Compiled) {
+    if (compileOutput.format() == Compile::Output::Format::Compiled) {
         std::string path = compileOutput.root() + "/" + "Assets.car";
 
         struct bom_context_memory memory = bom_context_memory_file(path.c_str(), true, 0);

--- a/Libraries/acdriver/Tests/test_CompileOutput.cpp
+++ b/Libraries/acdriver/Tests/test_CompileOutput.cpp
@@ -8,11 +8,11 @@
  */
 
 #include <gtest/gtest.h>
-#include <acdriver/CompileOutput.h>
+#include <acdriver/Compile/Output.h>
 #include <acdriver/Result.h>
 #include <libutil/MemoryFilesystem.h>
 
-using acdriver::CompileOutput;
+namespace Compile = acdriver::Compile;
 using acdriver::Result;
 using libutil::MemoryFilesystem;
 
@@ -25,7 +25,7 @@ Contents(std::string const &string)
 TEST(CompileOutput, Empty)
 {
     MemoryFilesystem filesystem = MemoryFilesystem({ });
-    CompileOutput output = CompileOutput("/", CompileOutput::Format::Compiled);
+    Compile::Output output = Compile::Output("/", Compile::Output::Format::Compiled);
 
     Result result;
     EXPECT_TRUE(output.write(&filesystem, ext::nullopt, ext::nullopt, &result));
@@ -40,7 +40,7 @@ TEST(CompileOutput, Copy)
     });
 
     /* Copy files from input to output. */
-    CompileOutput output = CompileOutput("/", CompileOutput::Format::Compiled);
+    Compile::Output output = Compile::Output("/", Compile::Output::Format::Compiled);
     output.copies().push_back({ "/source1", "/dest1" });
     output.copies().push_back({ "/source2", "/dest2" });
 


### PR DESCRIPTION
 - Move asset compilation output into the `acdriver::Compile` namespace.
 - Centralize various conversion functions so they can be shared between asset types.

This is a prerequisite for a later PR that adds support for compiling launch images.