### PR TITLE
No error if there is no dependancy info to write

### DIFF
--- a/Libraries/acdriver/Sources/CompileOutput.cpp
+++ b/Libraries/acdriver/Sources/CompileOutput.cpp
@@ -81,7 +81,8 @@ write(Filesystem *filesystem, ext::optional<std::string> const &partialInfoPlist
      * Write out dependency info, if requested.
      */
     if (dependencyInfo) {
-        if (!filesystem->write(_dependencyInfo.serialize(), *dependencyInfo)) {
+        auto contents = _dependencyInfo.serialize();
+        if (contents.size() > 0 && !filesystem->write(contents, *dependencyInfo)) {
             result->normal(Result::Severity::Error, "unable to write dependency info");
             success = false;
         }


### PR DESCRIPTION
We currently fail if actool is called with --export-dependency-info specified.