### PR TITLE
WIP Use lzfse as a portable alternative to libcompression.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "ThirdParty/googletest"]
 	path = ThirdParty/googletest
 	url = https://github.com/google/googletest.git
+[submodule "ThirdParty/lzfse"]
+	path = ThirdParty/lzfse
+	url = git@github.com:lzfse/lzfse.git

--- a/LICENSE
+++ b/LICENSE
@@ -160,3 +160,34 @@ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
 CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+## lzfse
+
+Copyright (c) 2015-2016, Apple Inc. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:  
+
+1.  Redistributions of source code must retain the above copyright notice,
+    this list of conditions and the following disclaimer.
+
+2.  Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+3.  Neither the name of the copyright holder(s) nor the names of any contributors
+    may be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGE.
+

--- a/Libraries/libcar/CMakeLists.txt
+++ b/Libraries/libcar/CMakeLists.txt
@@ -20,12 +20,24 @@ find_package(ZLIB REQUIRED)
 target_include_directories(car PRIVATE "${ZLIB_INCLUDE_DIR}")
 target_link_libraries(car PRIVATE ${ZLIB_LIBRARIES})
 
-find_library(COMPRESSION compression)
-if ("${COMPRESSION}" STREQUAL "COMPRESSION-NOTFOUND")
-  set(COMPRESSION "")
+set(LZFSE_SOURCE_DIR "${PROJECT_SOURCE_DIR}/ThirdParty/lzfse")
+if (IS_DIRECTORY "${LZFSE_SOURCE_DIR}")
+  set(LZFSE_BINARY_DIR "${PROJECT_BINARY_DIR}/lzfse") 
+  set(LZFSE_BUNDLE_MODE FALSE)
+  add_subdirectory("${LZFSE_SOURCE_DIR}" "${LZFSE_BINARY_DIR}" EXCLUDE_FROM_ALL)
+
+  target_compile_definitions(car PRIVATE HAVE_LZFSE=1)
+  target_link_libraries(car PRIVATE lzfse)
+  target_include_directories(car PRIVATE "${LZFSE_SOURCE_DIR}/src")
 endif ()
 
-target_link_libraries(car PUBLIC ext bom ${COMPRESSION})
+find_library(COMPRESSION compression)
+if (NOT "${COMPRESSION}" STREQUAL "COMPRESSION-NOTFOUND")
+  target_compile_definitions(car PRIVATE HAVE_COMPRESSION=1)
+  target_link_libraries(car PRIVATE "${COMPRESSION}") 
+endif ()
+
+target_link_libraries(car PUBLIC ext bom)
 target_include_directories(car PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/Headers")
 install(TARGETS car DESTINATION usr/lib)
 


### PR DESCRIPTION
WIP pending https://github.com/lzfse/lzfse/pull/25 and https://github.com/lzfse/lzfse/pull/26.

Allows decompressing LZFSE and LZVN compression on Linux.

Should the lzfse submodule be required? That would make the default build require git submodules be cloned, which isn't necessarily right now. Alternatively, could make either libcompression or lzfse required, or leave them both as optional.