### PR TITLE
Make reading and writing CAR files faster

### DIFF
--- a/Libraries/acdriver/Sources/CompileAction.cpp
+++ b/Libraries/acdriver/Sources/CompileAction.cpp
@@ -174,7 +174,7 @@ CreateWriter(std::string const &path)
         return ext::nullopt;
     }
 
-    auto bom = car::Writer::unique_ptr_bom(bom_alloc_size(memory, 0), bom_free);
+    auto bom = car::Writer::unique_ptr_bom(bom_alloc_empty(memory), bom_free);
     if (bom == nullptr) {
         return ext::nullopt;
     }

--- a/Libraries/acdriver/Sources/CompileAction.cpp
+++ b/Libraries/acdriver/Sources/CompileAction.cpp
@@ -174,7 +174,7 @@ CreateWriter(std::string const &path)
         return ext::nullopt;
     }
 
-    auto bom = car::Writer::unique_ptr_bom(bom_alloc_empty(memory), bom_free);
+    auto bom = car::Writer::unique_ptr_bom(bom_alloc_size(memory, 0), bom_free);
     if (bom == nullptr) {
         return ext::nullopt;
     }

--- a/Libraries/libbom/Headers/bom/bom.h
+++ b/Libraries/libbom/Headers/bom/bom.h
@@ -42,6 +42,9 @@ struct bom_context *
 bom_alloc_empty(struct bom_context_memory memory);
 
 struct bom_context *
+bom_alloc_size(struct bom_context_memory memory, uint32_t index_count);
+
+struct bom_context *
 bom_alloc_load(struct bom_context_memory memory);
 
 struct bom_context_memory const *
@@ -88,6 +91,9 @@ struct bom_tree_context;
 
 struct bom_tree_context *
 bom_tree_alloc_empty(struct bom_context *context, const char *variable_name);
+
+struct bom_tree_context *
+bom_tree_alloc_size(struct bom_context *context, const char *variable_name, uint32_t index_count);
 
 struct bom_tree_context *
 bom_tree_alloc_load(struct bom_context *context, const char *variable_name);

--- a/Libraries/libbom/Headers/bom/bom.h
+++ b/Libraries/libbom/Headers/bom/bom.h
@@ -39,9 +39,6 @@ bom_context_memory_file(const char *fn, bool writeable, size_t minimum_size);
 struct bom_context;
 
 struct bom_context *
-bom_alloc_empty(struct bom_context_memory memory);
-
-struct bom_context *
 bom_alloc_size(struct bom_context_memory memory, uint32_t index_count);
 
 struct bom_context *
@@ -88,9 +85,6 @@ bom_variable_add(struct bom_context *context, const char *name, int data_index);
 /* Tree */
 
 struct bom_tree_context;
-
-struct bom_tree_context *
-bom_tree_alloc_empty(struct bom_context *context, const char *variable_name);
 
 struct bom_tree_context *
 bom_tree_alloc_size(struct bom_context *context, const char *variable_name, uint32_t index_count);

--- a/Libraries/libbom/Headers/bom/bom.h
+++ b/Libraries/libbom/Headers/bom/bom.h
@@ -39,7 +39,10 @@ bom_context_memory_file(const char *fn, bool writeable, size_t minimum_size);
 struct bom_context;
 
 struct bom_context *
-bom_alloc_size(struct bom_context_memory memory, uint32_t index_count);
+bom_alloc_empty(struct bom_context_memory memory);
+
+struct bom_context *
+bom_alloc_empty2(struct bom_context_memory memory, uint32_t index_count);
 
 struct bom_context *
 bom_alloc_load(struct bom_context_memory memory);
@@ -87,7 +90,10 @@ bom_variable_add(struct bom_context *context, const char *name, int data_index);
 struct bom_tree_context;
 
 struct bom_tree_context *
-bom_tree_alloc_size(struct bom_context *context, const char *variable_name, uint32_t index_count);
+bom_tree_alloc_empty(struct bom_context *context, const char *variable_name);
+
+struct bom_tree_context *
+bom_tree_alloc_empty2(struct bom_context *context, const char *variable_name, uint32_t index_count);
 
 struct bom_tree_context *
 bom_tree_alloc_load(struct bom_context *context, const char *variable_name);

--- a/Libraries/libbom/Headers/bom/bom.h
+++ b/Libraries/libbom/Headers/bom/bom.h
@@ -44,6 +44,9 @@ bom_alloc_empty(struct bom_context_memory memory);
 struct bom_context *
 bom_alloc_empty2(struct bom_context_memory memory, uint32_t index_count);
 
+void
+bom_alloc_indexes(struct bom_context *context, uint32_t index_count);
+
 struct bom_context *
 bom_alloc_load(struct bom_context_memory memory);
 

--- a/Libraries/libbom/Sources/bom.c
+++ b/Libraries/libbom/Sources/bom.c
@@ -40,12 +40,6 @@ _bom_alloc(struct bom_context_memory memory)
 }
 
 struct bom_context *
-bom_alloc_empty(struct bom_context_memory memory)
-{
-  return bom_alloc_size(memory, 2);
-}
-
-struct bom_context *
 bom_alloc_size(struct bom_context_memory memory, uint32_t index_count)
 {
     struct bom_context *context = _bom_alloc(memory);

--- a/Libraries/libbom/Sources/bom.c
+++ b/Libraries/libbom/Sources/bom.c
@@ -251,6 +251,10 @@ bom_index_add(struct bom_context *context, const void *data, size_t data_len)
     if (new_index_length > ntohl(header->index_length) - (sizeof(struct bom_index) * 2) ) {
         ptrdiff_t index_delta = sizeof(struct bom_index);
         _bom_address_resize(context, index_point, index_delta);
+
+        /* Re-fetch, invalidated by resize. */
+        header = (struct bom_header *)context->memory.data;
+
         header->index_length = htonl(ntohl(header->index_length) + sizeof(struct bom_index));        
     }
 

--- a/Libraries/libbom/Sources/bom.c
+++ b/Libraries/libbom/Sources/bom.c
@@ -38,7 +38,13 @@ _bom_alloc(struct bom_context_memory memory)
 }
 
 struct bom_context *
-bom_alloc_size(struct bom_context_memory memory, uint32_t index_count)
+bom_alloc_empty(struct bom_context_memory memory)
+{
+  return bom_alloc_empty2(memory, 2);
+}
+
+struct bom_context *
+bom_alloc_empty2(struct bom_context_memory memory, uint32_t index_count)
 {
     struct bom_context *context = _bom_alloc(memory);
     if (context == NULL) {

--- a/Libraries/libbom/Sources/bom.c
+++ b/Libraries/libbom/Sources/bom.c
@@ -51,7 +51,7 @@ bom_alloc_size(struct bom_context_memory memory, uint32_t index_count)
 
     size_t header_size = sizeof(struct bom_header);
     size_t index_size = sizeof(struct bom_index_header);
-    size_t freelist_size = sizeof(struct bom_index_header) + sizeof(struct bom_index) * index_count;
+    size_t freelist_size = sizeof(struct bom_index_header) + sizeof(struct bom_index) * (index_count + 2);
     size_t variables_size = sizeof(struct bom_variables);
     context->memory.resize(&context->memory, header_size + index_size + freelist_size + variables_size);
 

--- a/Libraries/libbom/Sources/bom.c
+++ b/Libraries/libbom/Sources/bom.c
@@ -123,7 +123,7 @@ bom_alloc_load(struct bom_context_memory memory)
 
     struct bom_variables *vars = (struct bom_variables *)((void *)header + ntohl(header->variables_offset));
     size_t vars_count = ntohl(vars->count);
-    if (vars_offset + vars_count * sizeof(struct bom_variable) > context->memory.size) {
+    if (vars_offset + sizeof(struct bom_variables) + vars_count * sizeof(struct bom_variable) > context->memory.size) {
         bom_free(context);
         return NULL;
     }

--- a/Libraries/libbom/Sources/bom_tree.c
+++ b/Libraries/libbom/Sources/bom_tree.c
@@ -53,12 +53,6 @@ _bom_tree_alloc(struct bom_context *context, const char *variable_name)
 }
 
 struct bom_tree_context *
-bom_tree_alloc_empty(struct bom_context *context, const char *variable_name)
-{
-    return bom_tree_alloc_size(context, variable_name, 0);
-}
-
-struct bom_tree_context *
 bom_tree_alloc_size(struct bom_context *context, const char *variable_name, uint32_t index_count)
 {
     struct bom_tree_context *tree_context = _bom_tree_alloc(context, variable_name);

--- a/Libraries/libbom/Sources/bom_tree.c
+++ b/Libraries/libbom/Sources/bom_tree.c
@@ -205,16 +205,11 @@ bom_tree_add(struct bom_tree_context *tree_context, const void *key, size_t key_
     struct bom_tree *tree = (struct bom_tree *)bom_index_get(tree_context->context, tree_index, NULL);
 
     int paths_index = ntohl(tree->child);
-    bool resize;
 
     size_t paths_length;
     struct bom_tree_entry *paths = (struct bom_tree_entry *)bom_index_get(tree_context->context, paths_index, &paths_length);
 
-    if ((ntohs(paths->count) + 1) * sizeof(struct bom_tree_entry_indexes) < paths_length) {
-        resize = false;
-    } else {
-        resize = true;
-
+    if ((ntohs(paths->count) + 1) * sizeof(struct bom_tree_entry_indexes) > paths_length) {
         /* Make room for the new index, extending the size as necessary. */
         bom_index_append(tree_context->context, paths_index, sizeof(struct bom_tree_entry_indexes));
 

--- a/Libraries/libbom/Sources/bom_tree.c
+++ b/Libraries/libbom/Sources/bom_tree.c
@@ -51,7 +51,13 @@ _bom_tree_alloc(struct bom_context *context, const char *variable_name)
 }
 
 struct bom_tree_context *
-bom_tree_alloc_size(struct bom_context *context, const char *variable_name, uint32_t index_count)
+bom_tree_alloc_empty(struct bom_context *context, const char *variable_name)
+{
+    return bom_tree_alloc_empty2(context, variable_name, 0);
+}
+
+struct bom_tree_context *
+bom_tree_alloc_empty2(struct bom_context *context, const char *variable_name, uint32_t index_count)
 {
     struct bom_tree_context *tree_context = _bom_tree_alloc(context, variable_name);
     if (tree_context == NULL) {

--- a/Libraries/libcar/Headers/car/Reader.h
+++ b/Libraries/libcar/Headers/car/Reader.h
@@ -49,6 +49,8 @@ private:
 
 private:
     Reader(unique_ptr_bom bom);
+
+public:
     void facetFastIterate(std::function<void(void *key, size_t key_len, void *value, size_t value_len)> const &facet) const;
     void renditionFastIterate(std::function<void(void *key, size_t key_len, void *value, size_t value_len)> const &iterator) const;
 
@@ -64,6 +66,18 @@ public:
      */
     struct car_key_format *keyfmt() const
     { return *_keyfmt; }
+
+    /*
+     * The number of Facets read
+     */
+    int facetCount() const
+    { return _facetValues.size(); }
+
+    /*
+     * The number of Renditions read
+     */
+     int renditionCount() const
+     { return _renditionValues.size(); }
 
 public:
     /*

--- a/Libraries/libcar/Headers/car/Writer.h
+++ b/Libraries/libcar/Headers/car/Writer.h
@@ -44,7 +44,7 @@ private:
     ext::optional<struct car_key_format *> _keyfmt;
     std::unordered_map<std::string, Facet> _facets;
     std::unordered_multimap<uint16_t, Rendition> _renditions;
-    std::vector<KeyValuePair> _raw_renditions;
+    std::vector<KeyValuePair> _rawRenditions;
 
 private:
     Writer(unique_ptr_bom bom);

--- a/Libraries/libcar/Headers/car/Writer.h
+++ b/Libraries/libcar/Headers/car/Writer.h
@@ -35,9 +35,16 @@ public:
     typedef std::unique_ptr<struct bom_context, decltype(&bom_free)> unique_ptr_bom;
 
 private:
+    typedef struct {
+        void *key; size_t key_len; void *value; size_t value_len;
+    } KeyValuePair;
+
+private:
     unique_ptr_bom _bom;
+    ext::optional<struct car_key_format *> _keyfmt;
     std::unordered_map<std::string, Facet> _facets;
     std::unordered_multimap<uint16_t, Rendition> _renditions;
+    std::vector<KeyValuePair> _raw_renditions;
 
 private:
     Writer(unique_ptr_bom bom);
@@ -59,6 +66,17 @@ public:
      * Add a rendition for a facet, allow lazy loading of data.
      */
     void addRendition(Rendition const &rendition);
+
+    /*
+     * Add a rendition for a facet, optimized for fast editing of CAR files
+     */
+    void addRendition(void *key, size_t key_len, void *value, size_t value_len);
+
+    /*
+     * The key format, optional and determined automatically if omitted.
+     */
+    ext::optional<struct car_key_format *> &keyfmt()
+    { return _keyfmt; }
 
 public:
     /*

--- a/Libraries/libcar/Headers/car/Writer.h
+++ b/Libraries/libcar/Headers/car/Writer.h
@@ -36,7 +36,7 @@ public:
 
 private:
     typedef struct {
-        void *key; size_t key_len; void *value; size_t value_len;
+        void *key; size_t keyLength; void *value; size_t valueLength;
     } KeyValuePair;
 
 private:
@@ -70,7 +70,7 @@ public:
     /*
      * Add a rendition for a facet, optimized for fast editing of CAR files
      */
-    void addRendition(void *key, size_t key_len, void *value, size_t value_len);
+    void addRendition(void *key, size_t keyLength, void *value, size_t valueLength);
 
     /*
      * The key format, optional and determined automatically if omitted.

--- a/Libraries/libcar/Sources/Writer.cpp
+++ b/Libraries/libcar/Sources/Writer.cpp
@@ -52,7 +52,7 @@ void Writer::
 addRendition(void *key, size_t key_len, void *value, size_t value_len)
 {
     KeyValuePair kv = {key, key_len, value, value_len};
-    _raw_renditions.emplace_back(kv);
+    _rawRenditions.emplace_back(kv);
 }
 
 static std::vector<enum car_attribute_identifier>
@@ -148,7 +148,7 @@ write() const
     }
 
     /* Write renditions. */
-    uint32_t rendition_count = _renditions.size() + _raw_renditions.size();
+    uint32_t rendition_count = _renditions.size() + _rawRenditions.size();
     struct bom_tree_context *renditions_tree_context = bom_tree_alloc_size(_bom.get(), car_renditions_variable, rendition_count);
     if (renditions_tree_context != NULL) {
         for (auto const &item : _renditions) {
@@ -161,7 +161,7 @@ write() const
                 reinterpret_cast<void const *>(rendition_value.data()),
                 rendition_value.size());
         }
-        for (auto const &item : _raw_renditions) {
+        for (auto const &item : _rawRenditions) {
             bom_tree_add(
                 renditions_tree_context,
                 item.key,

--- a/Libraries/libcar/Sources/Writer.cpp
+++ b/Libraries/libcar/Sources/Writer.cpp
@@ -51,7 +51,8 @@ addRendition(Rendition const &rendition)
 void Writer::
 addRendition(void *key, size_t key_len, void *value, size_t value_len)
 {
-  _raw_renditions.push_back({key, key_len, value, value_len});
+    KeyValuePair kv = {key, key_len, value, value_len};
+    _raw_renditions.emplace_back(kv);
 }
 
 static std::vector<enum car_attribute_identifier>

--- a/Libraries/libcar/Sources/Writer.cpp
+++ b/Libraries/libcar/Sources/Writer.cpp
@@ -119,7 +119,8 @@ write() const
     bom_variable_add(_bom.get(), car_key_format_variable, key_format_index);
 
     /* Write facets. */
-    struct bom_tree_context *facets_tree_context = bom_tree_alloc_empty(_bom.get(), car_facet_keys_variable);
+    uint32_t facet_count = _facets.size();
+    struct bom_tree_context *facets_tree_context = bom_tree_alloc_size(_bom.get(), car_facet_keys_variable, facet_count);
     if (facets_tree_context != NULL) {
         for (auto const &item : _facets) {
             auto facet_value = item.second.write();
@@ -134,7 +135,8 @@ write() const
     }
 
     /* Write renditions. */
-    struct bom_tree_context *renditions_tree_context = bom_tree_alloc_empty(_bom.get(), car_renditions_variable);
+    uint32_t rendition_count = _renditions.size();
+    struct bom_tree_context *renditions_tree_context = bom_tree_alloc_size(_bom.get(), car_renditions_variable, rendition_count);
     if (renditions_tree_context != NULL) {
         for (auto const &item : _renditions) {
             auto attributes_value = item.second.attributes().write(keyfmt->num_identifiers, keyfmt->identifier_list);

--- a/Libraries/libcar/Sources/Writer.cpp
+++ b/Libraries/libcar/Sources/Writer.cpp
@@ -81,6 +81,16 @@ DetermineKeyFormat(
 void Writer::
 write() const
 {
+    /*
+     * A fast write has pre-allocated space for BOM indexes
+     * A baseline of 6 indexes are required: CAR Header (1), Key Format (1), and FACET (2) and RENDITION (2) trees
+     * Each tree entry (facet or rendition) requires 2: one key index, one value index.
+     */
+    uint32_t facet_count = _facets.size();
+    uint32_t rendition_count = _renditions.size() + _rawRenditions.size();
+    uint32_t bom_index_count = 6 + facet_count * 2 + rendition_count * 2;
+    bom_alloc_indexes(_bom.get(), bom_index_count);
+
     /* Write header. */
     struct car_header *header = (struct car_header *)malloc(sizeof(struct car_header));
     if (header == NULL) {
@@ -132,7 +142,6 @@ write() const
     bom_variable_add(_bom.get(), car_key_format_variable, key_format_index);
 
     /* Write facets. */
-    uint32_t facet_count = _facets.size();
     struct bom_tree_context *facets_tree_context = bom_tree_alloc_empty2(_bom.get(), car_facet_keys_variable, facet_count);
     if (facets_tree_context != NULL) {
         for (auto const &item : _facets) {
@@ -148,7 +157,6 @@ write() const
     }
 
     /* Write renditions. */
-    uint32_t rendition_count = _renditions.size() + _rawRenditions.size();
     struct bom_tree_context *renditions_tree_context = bom_tree_alloc_empty2(_bom.get(), car_renditions_variable, rendition_count);
     if (renditions_tree_context != NULL) {
         for (auto const &item : _renditions) {

--- a/Libraries/libcar/Sources/Writer.cpp
+++ b/Libraries/libcar/Sources/Writer.cpp
@@ -165,9 +165,9 @@ write() const
             bom_tree_add(
                 renditions_tree_context,
                 item.key,
-                item.key_len,
+                item.keyLength,
                 item.value,
-                item.value_len);
+                item.valueLength);
         }
         bom_tree_free(renditions_tree_context);
     }

--- a/Libraries/libcar/Sources/Writer.cpp
+++ b/Libraries/libcar/Sources/Writer.cpp
@@ -133,7 +133,7 @@ write() const
 
     /* Write facets. */
     uint32_t facet_count = _facets.size();
-    struct bom_tree_context *facets_tree_context = bom_tree_alloc_size(_bom.get(), car_facet_keys_variable, facet_count);
+    struct bom_tree_context *facets_tree_context = bom_tree_alloc_empty2(_bom.get(), car_facet_keys_variable, facet_count);
     if (facets_tree_context != NULL) {
         for (auto const &item : _facets) {
             auto facet_value = item.second.write();
@@ -149,7 +149,7 @@ write() const
 
     /* Write renditions. */
     uint32_t rendition_count = _renditions.size() + _rawRenditions.size();
-    struct bom_tree_context *renditions_tree_context = bom_tree_alloc_size(_bom.get(), car_renditions_variable, rendition_count);
+    struct bom_tree_context *renditions_tree_context = bom_tree_alloc_empty2(_bom.get(), car_renditions_variable, rendition_count);
     if (renditions_tree_context != NULL) {
         for (auto const &item : _renditions) {
             auto attributes_value = item.second.attributes().write(keyfmt->num_identifiers, keyfmt->identifier_list);

--- a/Libraries/libcar/Tests/test_Writer.cpp
+++ b/Libraries/libcar/Tests/test_Writer.cpp
@@ -41,7 +41,7 @@ TEST(Writer, TestWriter)
     int height = 8;
 
     /* Write out. */
-    auto writer_bom = car::Writer::unique_ptr_bom(bom_alloc_size(bom_context_memory(NULL, 0), 0), bom_free);
+    auto writer_bom = car::Writer::unique_ptr_bom(bom_alloc_empty(bom_context_memory(NULL, 0)), bom_free);
     EXPECT_NE(writer_bom, nullptr);
 
     auto writer = car::Writer::Create(std::move(writer_bom));
@@ -110,7 +110,7 @@ TEST(Writer, TestWriter100)
     /* Write out. */
     /* Write with half the required number of pre-allocated indexes */
     int preallocated_index_count = 6 + create_facet_count * 2 + create_rendition_count * 2;
-    auto writer_bom = car::Writer::unique_ptr_bom(bom_alloc_size(bom_context_memory(NULL, 0), preallocated_index_count / 2), bom_free);
+    auto writer_bom = car::Writer::unique_ptr_bom(bom_alloc_empty2(bom_context_memory(NULL, 0), preallocated_index_count / 2), bom_free);
     EXPECT_NE(writer_bom, nullptr);
 
     auto writer = car::Writer::Create(std::move(writer_bom));
@@ -188,7 +188,7 @@ TEST(Writer, TestWriter100Optimal)
      * Each tree entry (facet or rendition) requires 2: one key index, one value index.
      */
     unsigned int preallocated_index_count = 6 + create_facet_count * 2 + create_rendition_count * 2;
-    auto writer_bom = car::Writer::unique_ptr_bom(bom_alloc_size(bom_context_memory(NULL, 0), preallocated_index_count), bom_free);
+    auto writer_bom = car::Writer::unique_ptr_bom(bom_alloc_empty2(bom_context_memory(NULL, 0), preallocated_index_count), bom_free);
     EXPECT_NE(writer_bom, nullptr);
 
     auto writer = car::Writer::Create(std::move(writer_bom));

--- a/Libraries/libcar/Tests/test_Writer.cpp
+++ b/Libraries/libcar/Tests/test_Writer.cpp
@@ -41,7 +41,7 @@ TEST(Writer, TestWriter)
     int height = 8;
 
     /* Write out. */
-    auto writer_bom = car::Writer::unique_ptr_bom(bom_alloc_empty(bom_context_memory(NULL, 0)), bom_free);
+    auto writer_bom = car::Writer::unique_ptr_bom(bom_alloc_size(bom_context_memory(NULL, 0), 0), bom_free);
     EXPECT_NE(writer_bom, nullptr);
 
     auto writer = car::Writer::Create(std::move(writer_bom));
@@ -96,5 +96,160 @@ TEST(Writer, TestWriter)
 
     EXPECT_EQ(facet_count, 1);
     EXPECT_EQ(rendition_count, 1);
+}
+
+
+TEST(Writer, TestWriter100)
+{
+    int width = 8;
+    int height = 8;
+    int create_facet_count = 100;
+    int create_scales_count = 3;
+    int create_rendition_count = create_facet_count * create_scales_count;
+
+    /* Write out. */
+    /* Write with half the required number of pre-allocated indexes */
+    int preallocated_index_count = 6 + create_facet_count * 2 + create_rendition_count * 2;
+    auto writer_bom = car::Writer::unique_ptr_bom(bom_alloc_size(bom_context_memory(NULL, 0), preallocated_index_count / 2), bom_free);
+    // auto writer_bom = car::Writer::unique_ptr_bom(bom_alloc_size(bom_context_memory(NULL, 0), 0), bom_free);
+    EXPECT_NE(writer_bom, nullptr);
+
+    auto writer = car::Writer::Create(std::move(writer_bom));
+    EXPECT_NE(writer, ext::nullopt);
+
+    for (int facet_identifier = 1; facet_identifier <= create_facet_count; facet_identifier++) {
+      car::AttributeList attributes = car::AttributeList({
+          { car_attribute_identifier_idiom, car_attribute_identifier_idiom_value_universal },
+          { car_attribute_identifier_scale, 2 },
+          { car_attribute_identifier_identifier, facet_identifier },
+      });
+
+      car::Facet facet = car::Facet::Create("testpattern_" + std::to_string(facet_identifier), attributes);
+      writer->addFacet(facet);
+
+      for (int scale = 1; scale <= create_scales_count; scale++) {
+        auto data = car::Rendition::Data(test_pixels, car::Rendition::Data::Format::PremultipliedBGRA8);
+        car::Rendition rendition = car::Rendition::Create(attributes, data);
+        rendition.width() = width;
+        rendition.height() = height;
+        rendition.scale() = scale;
+        rendition.fileName() = "testpattern_" + std::to_string(facet_identifier) + "@" + std::to_string(scale) + "x.png";
+        rendition.layout() = car_rendition_value_layout_one_part_scale;
+        writer->addRendition(rendition);
+      }
+    }
+
+    writer->write();
+
+    /* Read back. */
+    struct bom_context_memory const *writer_memory = bom_memory(writer->bom());
+    struct bom_context_memory reader_memory = bom_context_memory(writer_memory->data, writer_memory->size);
+    auto reader_bom = std::unique_ptr<struct bom_context, decltype(&bom_free)>(bom_alloc_load(reader_memory), bom_free);
+    EXPECT_NE(reader_bom, nullptr);
+
+    ext::optional<car::Reader> reader = car::Reader::Load(std::move(reader_bom));
+    EXPECT_NE(reader, ext::nullopt);
+
+    int facet_count = 0;
+    int rendition_count = 0;
+
+    reader->facetIterate([&reader, &facet_count, &rendition_count](car::Facet const &facet) {
+        facet_count++;
+
+        ext::optional<uint16_t> facet_identifier = facet.attributes().get(car_attribute_identifier_identifier);
+        EXPECT_FALSE(facet_identifier == ext::nullopt);
+        EXPECT_EQ(facet.name(), "testpattern_" + std::to_string(*facet_identifier));
+
+        auto renditions = reader->lookupRenditions(facet);
+        for (auto const &rendition : renditions) {
+            rendition_count++;
+
+            auto data = rendition.data()->data();
+            EXPECT_EQ(data, test_pixels);
+            std::string fileName = "testpattern_" + std::to_string(*facet_identifier) + "@" + std::to_string((int)rendition.scale()) + "x.png";
+            EXPECT_TRUE(strcmp(rendition.fileName().c_str(), fileName.c_str()) == 0);
+        }
+    });
+
+    EXPECT_EQ(facet_count, create_facet_count);
+    EXPECT_EQ(rendition_count, create_rendition_count);
+}
+
+TEST(Writer, TestWriter100Optimal)
+{
+    int width = 8;
+    int height = 8;
+    int create_facet_count = 100;
+    int create_scales_count = 3;
+    int create_rendition_count = create_facet_count * create_scales_count;
+
+    /* Write out.
+     * A fast write has pre-allocated space for BOM indexes
+     * A baseline of 6 indexes are required: CAR Header (1), Key Format (1), and FACET (2) and RENDITION (2) trees
+     * Each tree entry (facet or rendition) requires 2: one key index, one value index.
+     */
+    unsigned int preallocated_index_count = 6 + create_facet_count * 2 + create_rendition_count * 2;
+    auto writer_bom = car::Writer::unique_ptr_bom(bom_alloc_size(bom_context_memory(NULL, 0), preallocated_index_count), bom_free);
+    EXPECT_NE(writer_bom, nullptr);
+
+    auto writer = car::Writer::Create(std::move(writer_bom));
+    EXPECT_NE(writer, ext::nullopt);
+
+    for (int facet_identifier = 1; facet_identifier <= create_facet_count; facet_identifier++) {
+      car::AttributeList attributes = car::AttributeList({
+          { car_attribute_identifier_idiom, car_attribute_identifier_idiom_value_universal },
+          { car_attribute_identifier_scale, 2 },
+          { car_attribute_identifier_identifier, facet_identifier },
+      });
+
+      car::Facet facet = car::Facet::Create("testpattern_" + std::to_string(facet_identifier), attributes);
+      writer->addFacet(facet);
+
+      for (int scale = 1; scale <= create_scales_count; scale++) {
+        auto data = car::Rendition::Data(test_pixels, car::Rendition::Data::Format::PremultipliedBGRA8);
+        car::Rendition rendition = car::Rendition::Create(attributes, data);
+        rendition.width() = width;
+        rendition.height() = height;
+        rendition.scale() = scale;
+        rendition.fileName() = "testpattern_" + std::to_string(facet_identifier) + "@" + std::to_string(scale) + "x.png";
+        rendition.layout() = car_rendition_value_layout_one_part_scale;
+        writer->addRendition(rendition);
+      }
+    }
+
+    writer->write();
+
+    /* Read back. */
+    struct bom_context_memory const *writer_memory = bom_memory(writer->bom());
+    struct bom_context_memory reader_memory = bom_context_memory(writer_memory->data, writer_memory->size);
+    auto reader_bom = std::unique_ptr<struct bom_context, decltype(&bom_free)>(bom_alloc_load(reader_memory), bom_free);
+    EXPECT_NE(reader_bom, nullptr);
+
+    ext::optional<car::Reader> reader = car::Reader::Load(std::move(reader_bom));
+    EXPECT_NE(reader, ext::nullopt);
+
+    int facet_count = 0;
+    int rendition_count = 0;
+
+    reader->facetIterate([&reader, &facet_count, &rendition_count](car::Facet const &facet) {
+        facet_count++;
+
+        ext::optional<uint16_t> facet_identifier = facet.attributes().get(car_attribute_identifier_identifier);
+        EXPECT_FALSE(facet_identifier == ext::nullopt);
+        EXPECT_EQ(facet.name(), "testpattern_" + std::to_string(*facet_identifier));
+
+        auto renditions = reader->lookupRenditions(facet);
+        for (auto const &rendition : renditions) {
+            rendition_count++;
+
+            auto data = rendition.data()->data();
+            EXPECT_EQ(data, test_pixels);
+            std::string fileName = "testpattern_" + std::to_string(*facet_identifier) + "@" + std::to_string((int)rendition.scale()) + "x.png";
+            EXPECT_TRUE(strcmp(rendition.fileName().c_str(), fileName.c_str()) == 0);
+        }
+    });
+
+    EXPECT_EQ(facet_count, create_facet_count);
+    EXPECT_EQ(rendition_count, create_rendition_count);
 }
 

--- a/Libraries/libcar/Tests/test_Writer.cpp
+++ b/Libraries/libcar/Tests/test_Writer.cpp
@@ -111,7 +111,6 @@ TEST(Writer, TestWriter100)
     /* Write with half the required number of pre-allocated indexes */
     int preallocated_index_count = 6 + create_facet_count * 2 + create_rendition_count * 2;
     auto writer_bom = car::Writer::unique_ptr_bom(bom_alloc_size(bom_context_memory(NULL, 0), preallocated_index_count / 2), bom_free);
-    // auto writer_bom = car::Writer::unique_ptr_bom(bom_alloc_size(bom_context_memory(NULL, 0), 0), bom_free);
     EXPECT_NE(writer_bom, nullptr);
 
     auto writer = car::Writer::Create(std::move(writer_bom));


### PR DESCRIPTION
Avoid memmoves in the libbom by optionally preallocating space for the indexes
Allow raw reads and writes of rendition key-value pairs
Allow specifying the key format to the writer