### PR TITLE
[xcsdk] Properly print out the SDK version when asked

### DIFF
--- a/Libraries/xcsdk/Headers/xcsdk/SDK/Target.h
+++ b/Libraries/xcsdk/Headers/xcsdk/SDK/Target.h
@@ -41,7 +41,7 @@ public:
     std::string              _path;
     std::string              _bundleName;
     std::string              _version;
-    std::string               _canonicalName;
+    std::string              _canonicalName;
     std::string              _displayName;
     std::string              _minimalDisplayName;
     std::string              _maximumDeploymentTarget;

--- a/Libraries/xcsdk/Tools/xcrun.cpp
+++ b/Libraries/xcsdk/Tools/xcrun.cpp
@@ -350,7 +350,7 @@ main(int argc, char **argv)
         printf("%s\n", target->path().c_str());
         return 0;
     } else if (options.showSDKVersion()) {
-        printf("%s\n", target->path().c_str());
+        printf("%s\n", target->version().c_str());
         return 0;
     } else if (options.showSDKBuildVersion()) {
         if (auto product = target->product()) {


### PR DESCRIPTION
Test plan:

/path/to/xcbuild/bin/xcrun --sdk iphoneos --show-sdk-version
9.2

Before it would print out the name of the SDK.