### PR TITLE
WIP Generate VFS for importing header maps.

### DIFF
--- a/Libraries/pbxbuild/Headers/pbxbuild/Tool/HeadermapInfo.h
+++ b/Libraries/pbxbuild/Headers/pbxbuild/Tool/HeadermapInfo.h
@@ -17,8 +17,11 @@ namespace Tool {
 
 class HeadermapInfo {
 private:
-    std::vector<std::string> _systemHeadermapFiles;
-    std::vector<std::string> _userHeadermapFiles;
+    std::vector<std::string>   _systemHeadermapFiles;
+    std::vector<std::string>   _userHeadermapFiles;
+
+private:
+    ext::optional<std::string> _overlayVFS;
 
 public:
     HeadermapInfo();
@@ -35,6 +38,14 @@ public:
     { return _systemHeadermapFiles; }
     std::vector<std::string> &userHeadermapFiles()
     { return _userHeadermapFiles; }
+
+public:
+    ext::optional<std::string> const &overlayVFS() const
+    { return _overlayVFS; }
+
+public:
+    ext::optional<std::string> &overlayVFS()
+    { return _overlayVFS; }
 };
 
 }

--- a/Libraries/pbxbuild/Sources/Tool/CompilerCommon.cpp
+++ b/Libraries/pbxbuild/Sources/Tool/CompilerCommon.cpp
@@ -33,6 +33,11 @@ AppendIncludePathFlags(std::vector<std::string> *args, pbxsetting::Environment c
     AppendCompoundFlags(args, "-I", true, headermapInfo.systemHeadermapFiles());
     AppendCompoundFlags(args, "-iquote", false, headermapInfo.userHeadermapFiles());
 
+    if (headermapInfo.overlayVFS()) {
+        args->push_back("-ivfsoverlay");
+        args->push_back(*headermapInfo.overlayVFS());
+    }
+
     if (environment.resolve("USE_HEADER_SYMLINKS") == "YES") {
         // TODO(grp): Create this symlink tree as needed.
         AppendCompoundFlags(args, "-I", true, { environment.resolve("CPP_HEADER_SYMLINKS_DIR") });


### PR DESCRIPTION
The main issue here is that the generated VFS is not per-target! It's
an auxiliary file that contains information from all targets and goes
in a target-independent directory. This doesn't match with either the
auxiliary file model or more generally the entire build structure:

 - Can anything specific to a build affect the VFS? If so, what if
   separarate builds are running in parallel from the same project?
 - If two targets in a build are from the same project, they should
   only need to generate the VFS once, and not more than once.