### PR TITLE
Preload external build configuration files at project load time.

### DIFF
--- a/Libraries/pbxbuild/Headers/pbxbuild/Target/Environment.h
+++ b/Libraries/pbxbuild/Headers/pbxbuild/Target/Environment.h
@@ -50,10 +50,6 @@ private:
     std::vector<std::string>                 _architectures;
 
 private:
-    ext::optional<pbxsetting::XC::Config>    _projectConfigurationFile;
-    ext::optional<pbxsetting::XC::Config>    _targetConfigurationFile;
-
-private:
     std::string                              _workingDirectory;
     std::unordered_map<pbxproj::PBX::BuildFile::shared_ptr, std::string> _buildFileDisambiguation;
 
@@ -70,8 +66,6 @@ private:
         std::shared_ptr<pbxsetting::Environment> const &environment,
         std::vector<std::string> const &variants,
         std::vector<std::string> const &architectures,
-        ext::optional<pbxsetting::XC::Config> const &projectConfigurationFile,
-        ext::optional<pbxsetting::XC::Config> const &targetConfigurationFile,
         std::string const &workingDirectory,
         std::unordered_map<pbxproj::PBX::BuildFile::shared_ptr, std::string> const &buildFileDisambiguation);
 
@@ -147,19 +141,6 @@ public:
      */
     std::vector<std::string> const &architectures() const
     { return _architectures; }
-
-public:
-    /*
-     * The configuration files loaded for the project in this configuration.
-     */
-    ext::optional<pbxsetting::XC::Config> const &projectConfigurationFile() const
-    { return _projectConfigurationFile; }
-
-    /*
-     * The configuration files loaded for this target and configuration.
-     */
-    ext::optional<pbxsetting::XC::Config> const &targetConfigurationFile() const
-    { return _targetConfigurationFile; }
 
 public:
     /*

--- a/Libraries/pbxbuild/Headers/pbxbuild/WorkspaceContext.h
+++ b/Libraries/pbxbuild/Headers/pbxbuild/WorkspaceContext.h
@@ -12,6 +12,7 @@
 
 #include <pbxbuild/Base.h>
 #include <pbxbuild/DerivedDataHash.h>
+#include <pbxsetting/XC/Config.h>
 
 namespace pbxsetting { class Environment; }
 namespace libutil { class Filesystem; }
@@ -35,6 +36,7 @@ private:
     pbxproj::PBX::Project::shared_ptr              _project;
     std::vector<xcscheme::SchemeGroup::shared_ptr> _schemeGroups;
     std::unordered_map<std::string, pbxproj::PBX::Project::shared_ptr> _projects;
+    std::unordered_map<pbxproj::XC::BuildConfiguration::shared_ptr, pbxsetting::XC::Config> _configs;
 
 public:
     WorkspaceContext(
@@ -43,7 +45,8 @@ public:
         xcworkspace::XC::Workspace::shared_ptr const &workspace,
         pbxproj::PBX::Project::shared_ptr const &project,
         std::vector<xcscheme::SchemeGroup::shared_ptr> const &schemeGroups,
-        std::unordered_map<std::string, pbxproj::PBX::Project::shared_ptr> const &projects);
+        std::unordered_map<std::string, pbxproj::PBX::Project::shared_ptr> const &projects,
+        std::unordered_map<pbxproj::XC::BuildConfiguration::shared_ptr, pbxsetting::XC::Config> const &configs);
     ~WorkspaceContext();
 
 public:
@@ -84,6 +87,12 @@ public:
      */
     std::unordered_map<std::string, pbxproj::PBX::Project::shared_ptr> const &projects() const
     { return _projects; }
+
+    /*
+     * All configuration files, including for all loaded projects and targets.
+     */
+    std::unordered_map<pbxproj::XC::BuildConfiguration::shared_ptr, pbxsetting::XC::Config> const &configs() const
+    { return _configs; }
 
 public:
     /*

--- a/Libraries/pbxproj/Headers/pbxproj/XC/ConfigurationList.h
+++ b/Libraries/pbxproj/Headers/pbxproj/XC/ConfigurationList.h
@@ -27,27 +27,12 @@ public:
     ConfigurationList();
 
 public:
-    inline void setDefaultConfigurationName(std::string const &name)
-    { _defaultConfigurationName = name; }
+    inline BuildConfiguration::vector const &buildConfigurations() const
+    { return _buildConfigurations; }
     inline std::string const &defaultConfigurationName() const
     { return _defaultConfigurationName; }
-
-public:
-    inline void setDefaultConfigurationIsVisible(bool visible)
-    { _defaultConfigurationIsVisible = visible; }
     inline bool defaultConfigurationIsVisible() const
     { return _defaultConfigurationIsVisible; }
-
-public:
-    inline BuildConfiguration::vector::const_iterator begin() const
-    { return _buildConfigurations.begin(); }
-    inline BuildConfiguration::vector::const_iterator end() const
-    { return _buildConfigurations.end(); }
-
-    inline BuildConfiguration::vector::iterator begin()
-    { return _buildConfigurations.begin(); }
-    inline BuildConfiguration::vector::iterator end()
-    { return _buildConfigurations.end(); }
 
 protected:
     bool parse(Context &context, plist::Dictionary const *dict, std::unordered_set<std::string> *seen, bool check) override;

--- a/Libraries/pbxproj/Tools/dump_xcodeproj.cpp
+++ b/Libraries/pbxproj/Tools/dump_xcodeproj.cpp
@@ -57,7 +57,7 @@ GenerateConfigurationSettings(Filesystem const *filesystem,
     std::unique_ptr<plist::Dictionary> settings = nullptr;
 
     if (!isProjectBC) {
-        for (auto PBC : *project->buildConfigurationList()) {
+        for (auto const &PBC : project->buildConfigurationList()->buildConfigurations()) {
             if (BC.name() == PBC->name()) {
                 settings = GenerateConfigurationSettings(filesystem, project, *PBC, true);
                 break;
@@ -221,7 +221,7 @@ CompleteDump(Filesystem const *filesystem, PBX::Project::shared_ptr const &proje
         }
         printf("\t\tConfigurations:\n");
         auto DCN = I->buildConfigurationList()->defaultConfigurationName();
-        for (auto J : *I->buildConfigurationList()) {
+        for (auto const &J : I->buildConfigurationList()->buildConfigurations()) {
             printf("\t\t\t%s%s\n", J->name().c_str(),
                     J->name() == DCN ?  " [Default]" : "");
         }
@@ -430,7 +430,7 @@ main(int argc, char **argv)
 
     if (project->buildConfigurationList()) {
         printf("%4sBuild Configurations:\n", "");
-        for (auto config : *project->buildConfigurationList()) {
+        for (auto const &config : project->buildConfigurationList()->buildConfigurations()) {
             printf("%8s%s\n", "", config->name().c_str());
         }
         printf("\n%4sIf no build configuration is specified and -scheme "

--- a/Libraries/xcdriver/Sources/ListAction.cpp
+++ b/Libraries/xcdriver/Sources/ListAction.cpp
@@ -93,7 +93,7 @@ Run(Filesystem const *filesystem, Options const &options)
 
         if (project->buildConfigurationList()) {
             printf("%4sBuild Configurations:\n", "");
-            for (auto const &config : *project->buildConfigurationList()) {
+            for (auto const &config : project->buildConfigurationList()->buildConfigurations()) {
                 printf("%8s%s\n", "", config->name().c_str());
             }
             printf("\n%4sIf no build configuration is specified and -scheme is not passed then \"%s\" is used.\n", "", project->buildConfigurationList()->defaultConfigurationName().c_str());

--- a/Libraries/xcexecution/Sources/NinjaExecutor.cpp
+++ b/Libraries/xcexecution/Sources/NinjaExecutor.cpp
@@ -453,11 +453,6 @@ buildAction(
     writer.rule(NinjaRuleName(), ninja::Value::Expression("cd $dir && env -i $env $exec && $depexec"));
 
     /*
-     * Build up a list of all of the inputs to the build, so Ninja can regenerate as necessary.
-     */
-    std::vector<std::string> inputPaths = buildContext.workspaceContext().loadedFilePaths();
-
-    /*
      * Go over each target and write out Ninja targets for the start and end of each.
      * Don't bother topologically sorting the targets now, since Ninja will do that for us.
      */
@@ -570,17 +565,12 @@ buildAction(
             invocationOutputsValues.push_back(ninja::Value::String(output));
         }
         writer.build({ ninja::Value::String(targetFinish) }, "phony", { }, { }, invocationOutputsValues);
-
-        /*
-         * Add loaded files for the target configuration to the inputs.
-         */
-        if (auto projectConfigurationFile = targetEnvironment->projectConfigurationFile()) {
-            inputPaths.push_back(projectConfigurationFile->path());
-        }
-        if (auto targetConfigurationFile = targetEnvironment->targetConfigurationFile()) {
-            inputPaths.push_back(targetConfigurationFile->path());
-        }
     }
+
+    /*
+     * Build up a list of all of the inputs to the build, so Ninja can regenerate as necessary.
+     */
+    std::vector<std::string> inputPaths = buildContext.workspaceContext().loadedFilePaths();
 
     /*
      * Add a Ninja rule to regenerate the build.ninja file itself.


### PR DESCRIPTION
This avoids requiring filesystem access to compute the target environment,
and fixes the layering of build configurations when determining the target
SDK for the build.