### PR TITLE
[xcsdk] Allow xcrun to work with only --toolchains defined when finding tools

### DIFF
--- a/Libraries/pbxbuild/Sources/Target/Environment.cpp
+++ b/Libraries/pbxbuild/Sources/Target/Environment.cpp
@@ -440,7 +440,7 @@ Create(Build::Environment const &buildEnvironment, Build::Context const &buildCo
     }
 
     /* Tool search directories. Use the toolchains just discovered. */
-    std::vector<std::string> executablePaths = sdk->executablePaths(toolchains);
+    std::vector<std::string> executablePaths = buildEnvironment.sdkManager()->executablePaths(sdk, toolchains);
 
     auto buildRules = Target::BuildRules::Create(buildEnvironment.specManager(), specDomains, target);
     auto buildFileDisambiguation = BuildFileDisambiguation(target);

--- a/Libraries/xcsdk/Headers/xcsdk/SDK/Manager.h
+++ b/Libraries/xcsdk/Headers/xcsdk/SDK/Manager.h
@@ -80,7 +80,7 @@ public:
     /*
      * Default settings for the contents of the developer root.
      */
-    pbxsetting::Level computedSettings(void) const;
+    pbxsetting::Level computedSettings() const;
 
 public:
     /*
@@ -88,6 +88,12 @@ public:
      * root, rather than within a toolchain or a platform.
      */
     std::vector<std::string> executablePaths() const;
+
+    /*
+     * Conglomeration of executable paths that optionally includes extra toolchains
+     * and the paths from an SDK target.
+     */
+    std::vector<std::string> executablePaths(xcsdk::SDK::Target::shared_ptr const &target, std::vector<xcsdk::SDK::Toolchain::shared_ptr> const &toolchains) const;
 
 public:
     /*

--- a/Libraries/xcsdk/Sources/SDK/Manager.cpp
+++ b/Libraries/xcsdk/Sources/SDK/Manager.cpp
@@ -123,6 +123,27 @@ executablePaths() const
     };
 }
 
+std::vector<std::string> Manager::
+executablePaths(xcsdk::SDK::Target::shared_ptr const &target, std::vector<xcsdk::SDK::Toolchain::shared_ptr> const &toolchains) const
+{
+    std::vector<std::string> paths;
+
+    if (target != nullptr) {
+        std::vector<std::string> targetPaths = target->executablePaths(toolchains);
+        paths.insert(paths.end(), targetPaths.begin(), targetPaths.end());
+    } else {
+        for (Toolchain::shared_ptr const &toolchain : toolchains) {
+            std::vector<std::string> toolchainPaths = toolchain->executablePaths();
+            paths.insert(paths.end(), toolchainPaths.begin(), toolchainPaths.end());
+        }
+    }
+
+    std::vector<std::string> managerPaths = this->executablePaths();
+    paths.insert(paths.end(), managerPaths.begin(), managerPaths.end());
+
+    return paths;
+}
+
 std::shared_ptr<Manager> Manager::
 Open(Filesystem const *filesystem, std::string const &path, ext::optional<Configuration> const &configuration)
 {

--- a/Libraries/xcsdk/Sources/SDK/Target.cpp
+++ b/Libraries/xcsdk/Sources/SDK/Target.cpp
@@ -67,11 +67,6 @@ executablePaths(ext::optional<std::vector<Toolchain::shared_ptr>> const &overrid
         paths.insert(paths.end(), toolchainPaths.begin(), toolchainPaths.end());
     }
 
-    if (std::shared_ptr<Manager> manager = _manager.lock()) {
-        std::vector<std::string> managerPaths = manager->executablePaths();
-        paths.insert(paths.end(), managerPaths.begin(), managerPaths.end());
-    }
-
     return paths;
 }
 


### PR DESCRIPTION
If the tool isn't given an SDK, then it doesn't make sense to fail the
tool search if the asked-for tool lives inside one of the given
toolchains.

This also changes how 'xcrun' operates -- if there's no SDK target that can be found,
then that's OK so long as there's some sort of toolchain path that can be searched.

Suggestions for how to test this?

Change-Id: I17f8cd3fbe7d02ad31a6cdbbc016f5ab6ffe2f3c