### PR TITLE
Update asset compiler driver options to include and ignore new flags.

### DIFF
--- a/Libraries/acdriver/Headers/acdriver/Options.h
+++ b/Libraries/acdriver/Headers/acdriver/Options.h
@@ -57,6 +57,11 @@ private:
     ext::optional<std::string> _filterForDeviceModel;
     ext::optional<std::string> _filterForDeviceOsVersion;
 
+// Unimplmeneted/ignored
+private:
+    ext::optional<std::string> _stickerPackIdentifierPrefix;
+    ext::optional<std::string> _productType;    
+
 public:
     Options();
     ~Options();

--- a/Libraries/acdriver/Sources/Options.cpp
+++ b/Libraries/acdriver/Sources/Options.cpp
@@ -68,6 +68,10 @@ parseArgument(std::vector<std::string> const &args, std::vector<std::string>::co
         return libutil::Options::Next<std::string>(&_filterForDeviceModel, args, it);
     } else if (arg == "--filter-for-device-os-version") {
         return libutil::Options::Next<std::string>(&_filterForDeviceOsVersion, args, it);
+    } else if (arg == "--sticker-pack-identifier-prefix") {
+        return libutil::Options::Next<std::string>(&_stickerPackIdentifierPrefix, args, it);
+    } else if (arg == "--product-type") {
+        return libutil::Options::Next<std::string>(&_productType, args, it);
     } else if (!arg.empty() && arg[0] != '-') {
         return libutil::Options::AppendCurrent<std::string>(&_inputs, arg);
     } else {


### PR DESCRIPTION
There are two new arguments that need to be included in order to not fail builds:
- `--sticker-pack-identifier-prefix`
- `--product-type`

They've been added in a rudimentary way here to get around the build failures, but they're just ignored.
