### PR TITLE
Make libpng a required library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ project(xcbuild C CXX)
 cmake_minimum_required(VERSION 3.0)
 set(CMAKE_MACOSX_RPATH 1)
 
-if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+if ("${CMAKE_SYSTEM_NAME}" MATCHES "Darwin")
   set(CMAKE_INSTALL_RPATH "@executable_path/../lib")
 else ()
   set(CMAKE_INSTALL_RPATH "$ORIGIN/../lib")

--- a/Libraries/graphics/CMakeLists.txt
+++ b/Libraries/graphics/CMakeLists.txt
@@ -29,7 +29,7 @@ else ()
   find_package(PNG REQUIRED)
   target_link_libraries(graphics PUBLIC "${PNG_LIBRARIES}")
   target_include_directories(graphics PRIVATE "${PNG_INCLUDE_DIRS}")
-  set_target_properties(graphics PROPERTIES COMPILE_DEFINITIONS "${PNG_DEFINITIONS}")
+  target_compile_definitions(graphics PRIVATE "${PNG_DEFINITIONS}")
 endif ()
 
 install(TARGETS graphics DESTINATION usr/lib)

--- a/Libraries/graphics/CMakeLists.txt
+++ b/Libraries/graphics/CMakeLists.txt
@@ -12,37 +12,26 @@ add_library(graphics SHARED
             Sources/PixelFormat.cpp
             Sources/Format/PNG.cpp
             )
-
-find_library(CORE_FOUNDATION CoreFoundation)
-if ("${CORE_FOUNDATION}" STREQUAL "CORE_FOUNDATION-NOTFOUND")
-  set(CORE_FOUNDATION "")
-endif ()
-
-find_library(CORE_GRAPHICS CoreGraphics)
-if ("${CORE_GRAPHICS}" STREQUAL "CORE_GRAPHICS-NOTFOUND")
-  set(CORE_GRAPHICS "")
-endif ()
-
-find_library(IMAGE_IO ImageIO)
-if ("${IMAGE_IO}" STREQUAL "IMAGE_IO-NOTFOUND")
-  set(IMAGE_IO "")
-endif ()
-
-set(PNG_STATIC ON)
-find_package(PNG)
-if (NOT "${PNG_FOUND}")
-  set(PNG_LIBRARIES "")
-  set(PNG_INCLUDE_DIRS "")
-  set(PNG_DEFINITIONS "")
-endif ()
+target_link_libraries(graphics PUBLIC ext)
+target_include_directories(graphics PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/Headers")
 
 find_package(ZLIB REQUIRED)
-
-target_link_libraries(graphics PUBLIC ext ${ZLIB_LIBRARIES} ${PNG_LIBRARIES} ${CORE_FOUNDATION} ${CORE_GRAPHICS} ${IMAGE_IO})
-target_include_directories(graphics PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/Headers")
-target_include_directories(graphics PRIVATE ${PNG_INCLUDE_DIRS})
+target_link_libraries(graphics PUBLIC ext "${ZLIB_LIBRARIES}")
 target_include_directories(graphics PRIVATE "${ZLIB_INCLUDE_DIR}")
-set_target_properties(graphics PROPERTIES COMPILE_DEFINITIONS "${PNG_DEFINITIONS}")
+
+if ("${CMAKE_SYSTEM_NAME}" MATCHES "Darwin")
+  find_library(CORE_FOUNDATION CoreFoundation)
+  find_library(CORE_GRAPHICS CoreGraphics)
+  find_library(IMAGE_IO ImageIO)
+  target_link_libraries(graphics PUBLIC "${CORE_FOUNDATION}" "${CORE_GRAPHICS}" "${IMAGE_IO}")
+else ()
+  set(PNG_STATIC ON)
+  find_package(PNG REQUIRED)
+  target_link_libraries(graphics PUBLIC "${PNG_LIBRARIES}")
+  target_include_directories(graphics PRIVATE "${PNG_INCLUDE_DIRS}")
+  set_target_properties(graphics PROPERTIES COMPILE_DEFINITIONS "${PNG_DEFINITIONS}")
+endif ()
+
 install(TARGETS graphics DESTINATION usr/lib)
 
 if (BUILD_TESTING)

--- a/Libraries/plist/CMakeLists.txt
+++ b/Libraries/plist/CMakeLists.txt
@@ -58,8 +58,8 @@ add_library(plist SHARED
 
 find_package(LibXml2 REQUIRED)
 target_include_directories(plist PRIVATE "${LIBXML2_INCLUDE_DIR}")
+target_compile_definitions(plist PRIVATE "${LIBXML2_DEFINITIONS}")
 target_link_libraries(plist PRIVATE ${LIBXML2_LIBRARIES})
-set_target_properties(plist PROPERTIES COMPILE_DEFINITIONS "${LIBXML2_DEFINITIONS}")
 
 target_include_directories(plist PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/Headers")
 target_include_directories(plist PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/PrivateHeaders")


### PR DESCRIPTION
The project won't build without libpng anyway. Make it fatal in cmake
instead of hiding the failure and letting the build step fail instead.