### PR TITLE
Grab specifications from the correct domain

### DIFF
--- a/Libraries/pbxspec/Headers/pbxspec/Manager.h
+++ b/Libraries/pbxspec/Headers/pbxspec/Manager.h
@@ -146,7 +146,7 @@ public:
     Create(void);
 
 public:
-    static std::string
+    static std::string const &
     AnyDomain();
 
 public:

--- a/Libraries/pbxspec/Headers/pbxspec/Manager.h
+++ b/Libraries/pbxspec/Headers/pbxspec/Manager.h
@@ -131,7 +131,7 @@ public:
 
 private:
     void addSpecification(PBX::Specification::shared_ptr const &specification);
-    bool inheritSpecification(PBX::Specification::shared_ptr const &specification);
+    bool inheritSpecification(PBX::Specification::shared_ptr const &specification, std::vector<PBX::Specification::shared_ptr>);
 
 private:
     template <typename T>

--- a/Libraries/pbxspec/Headers/pbxspec/PBX/Specification.h
+++ b/Libraries/pbxspec/Headers/pbxspec/PBX/Specification.h
@@ -47,6 +47,10 @@ protected:
     Specification();
 
 public:
+    bool operator==(Specification const &rhs) const;
+    bool operator!=(Specification const &rhs) const;
+
+public:
     virtual SpecificationType type() const = 0;
 
 public:

--- a/Libraries/pbxspec/Sources/Manager.cpp
+++ b/Libraries/pbxspec/Sources/Manager.cpp
@@ -460,10 +460,11 @@ Create(void)
     return std::make_shared <Manager> ();
 }
 
-std::string Manager::
+std::string const &Manager::
 AnyDomain()
 {
-    return "<<domain>>";
+    static std::string any = "<<domain>>";
+    return any;
 }
 
 std::vector<std::pair<std::string, std::string>> Manager::

--- a/Libraries/pbxspec/Sources/PBX/Specification.cpp
+++ b/Libraries/pbxspec/Sources/PBX/Specification.cpp
@@ -40,7 +40,7 @@ Specification()
 bool Specification::
 operator==(Specification const &rhs) const
 {
-    return _identifier == rhs._identifier && _domain == rhs._domain;
+    return _identifier.compare(rhs._identifier) == 0 && _domain.compare(rhs._domain) == 0;
 }
 
 bool Specification::

--- a/Libraries/pbxspec/Sources/PBX/Specification.cpp
+++ b/Libraries/pbxspec/Sources/PBX/Specification.cpp
@@ -38,6 +38,18 @@ Specification()
 }
 
 bool Specification::
+operator==(Specification const &rhs) const
+{
+    return _identifier == rhs._identifier && _domain == rhs._domain;
+}
+
+bool Specification::
+operator!=(Specification const &rhs) const
+{
+    return !(*this == rhs);
+}
+
+bool Specification::
 inherit(Specification::shared_ptr const &base)
 {
     if (base == nullptr || base.get() == this)

--- a/Libraries/process/Sources/DefaultContext.cpp
+++ b/Libraries/process/Sources/DefaultContext.cpp
@@ -252,7 +252,7 @@ userHomeDirectory() const
     if (ext::optional<std::string> value = Context::userHomeDirectory()) {
         return value;
     } else {
-        char *home = getpwuid(getuid())->pw_dir;
+        char *home = ::getpwuid(::getuid())->pw_dir;
         return std::string(home);
     }
 }


### PR DESCRIPTION
This had the nasty side effect of breaking with a stack overflow when a `foo:identifier`
xcspec was `BasedOn` a `bar:identifier` xcspec. We were not enforcing the domain,
which meant we kept inheriting from ourselves over and over.
