### PR TITLE
Regenerate when the xcbuild binary changes

### DIFF
--- a/Libraries/xcexecution/Sources/NinjaExecutor.cpp
+++ b/Libraries/xcexecution/Sources/NinjaExecutor.cpp
@@ -191,6 +191,11 @@ WriteNinjaRegenerate(
     }
 
     /*
+     * If the generator has changed, the ninja file needs to be regenerated as well.
+     */
+    inputPathValues.push_back(ninja::Value::String(executablePath));
+
+    /*
      * Write out the Ninja rule to regenerate sources.
      */
     std::string ruleName = "regenerate";


### PR DESCRIPTION
If the generator itself (xcbuild) changes, we should regenerate the
ninja files too.