### PR TITLE
Preserve ordering of library search paths

### DIFF
--- a/Libraries/pbxbuild/Sources/Tool/LinkerResolver.cpp
+++ b/Libraries/pbxbuild/Sources/Tool/LinkerResolver.cpp
@@ -53,12 +53,22 @@ resolve(
         auxiliaries.push_back(fileList);
     }
 
-    std::unordered_set<std::string> libraryPaths;
+    /*
+     * Use an std::vector from which we'll remove duplicates later so we can
+     * preserve the ordering of our library search paths.
+     */
+    std::vector<std::string> libraryPaths;
+    libraryPaths.reserve(inputLibraries.size());
     for (Phase::File const &library : inputLibraries) {
         if (!library.fileType()->isFrameworkWrapper()) {
-            libraryPaths.insert(FSUtil::GetDirectoryName(library.path()));
+            libraryPaths.push_back(FSUtil::GetDirectoryName(library.path()));
         }
     }
+
+    // Eliminate duplicates.
+    libraryPaths.erase(std::unique(libraryPaths.begin(), libraryPaths.end()),
+                       libraryPaths.end());
+
     for (std::string const &libraryPath : libraryPaths) {
         special.push_back("-L" + libraryPath);
     }


### PR DESCRIPTION
If we don't do this correctly, we might end up picking the wrong library
to link against. This happened when building an app that has its own
copy of protobuf. `libprotobuf.tbd` from `iPhoneOS.sdk` was used instead
of `libprotobuf.a` from the app itself.