### PR TITLE
Link required libraries when using threading functions. Fixes #139.

### DIFF
--- a/Libraries/process/CMakeLists.txt
+++ b/Libraries/process/CMakeLists.txt
@@ -20,3 +20,5 @@ target_link_libraries(process PUBLIC ext util)
 target_include_directories(process PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/Headers")
 install(TARGETS process DESTINATION usr/lib)
 
+find_package(Threads REQUIRED)
+target_link_libraries(process PRIVATE ${CMAKE_THREAD_LIBS_INIT})


### PR DESCRIPTION
See #139.