### PR TITLE
[actool] Add --compile-output-filename option for specifying car filename

### DIFF
--- a/Libraries/acdriver/Headers/acdriver/Options.h
+++ b/Libraries/acdriver/Headers/acdriver/Options.h
@@ -35,6 +35,13 @@ private:
 
 private:
     ext::optional<std::string> _compile;
+
+    /*
+     * extension: allows changing the name of the output file, including the file extension.
+     * "Assets.car" will be used if unspecified.
+     */
+    ext::optional<std::string> _compileOutputFilename;
+
     ext::optional<std::string> _exportDependencyInfo;
 
 private:
@@ -73,7 +80,8 @@ public:
     { return _printContents.value_or(false); }
     ext::optional<std::string> const &compile() const
     { return _compile; }
-
+    ext::optional<std::string> const &compileOutputFilename() const
+    { return _compileOutputFilename; }
 public:
     ext::optional<std::string> const &outputFormat() const
     { return _outputFormat; }

--- a/Libraries/acdriver/Sources/CompileAction.cpp
+++ b/Libraries/acdriver/Sources/CompileAction.cpp
@@ -262,7 +262,8 @@ run(Filesystem *filesystem, Options const &options, Output *output, Result *resu
      * If necessary, create output archive to write into.
      */
     if (compileOutput.format() == Compile::Output::Format::Compiled) {
-        std::string path = compileOutput.root() + "/" + "Assets.car";
+        std::string outputFilename = options.compileOutputFilename().value_or("Assets.car");
+        std::string path = compileOutput.root() + "/" + outputFilename;
 
         ext::optional<car::Writer> writer = CreateWriter(path);
         if (!writer) {

--- a/Libraries/acdriver/Sources/Options.cpp
+++ b/Libraries/acdriver/Sources/Options.cpp
@@ -32,6 +32,8 @@ parseArgument(std::vector<std::string> const &args, std::vector<std::string>::co
         return libutil::Options::Current<bool>(&_printContents, arg);
     } else if (arg == "--compile") {
         return libutil::Options::Next<std::string>(&_compile, args, it);
+    } else if (arg == "--compile-output-filename") {
+        return libutil::Options::Next<std::string>(&_compileOutputFilename, args, it);
     } else if (arg == "--output-format") {
         return libutil::Options::Next<std::string>(&_outputFormat, args, it);
     } else if (arg == "--warnings") {


### PR DESCRIPTION
Having the option to customize the output path fully (not just the directory) is helpful in cases where the archives are being pre-generated, or there are multiple going into the same directory.