### PR TITLE
[process] Don't use the constructor attribute on Linux for grabbing command line arguments

### DIFF
--- a/Libraries/process/Sources/DefaultContext.cpp
+++ b/Libraries/process/Sources/DefaultContext.cpp
@@ -128,12 +128,18 @@ executablePath() const
 static int commandLineArgumentCount = 0;
 static char **commandLineArgumentValues = NULL;
 
+#if !defined(__linux__)
 __attribute__((constructor))
+#endif
 static void CommandLineArgumentsInitialize(int argc, char **argv)
 {
     commandLineArgumentCount = argc;
     commandLineArgumentValues = argv;
 }
+
+#if defined(__linux__)
+__attribute__((section(".init_array"))) auto commandLineArgumentInitializer = &CommandLineArgumentsInitialize;
+#endif
 
 std::vector<std::string> const &DefaultContext::
 commandLineArguments() const


### PR DESCRIPTION
h/t to @sas for this fix. This is a minimal fix for my problems when
using xcbuild tools on my Linux machine.

See https://github.com/facebook/xcbuild/issues/138