### PR TITLE
Add definitions for some newer asset archive format fields.

### DIFF
--- a/Libraries/libcar/Headers/car/car_format.h
+++ b/Libraries/libcar/Headers/car/car_format.h
@@ -108,9 +108,11 @@ enum car_attribute_identifier {
     car_attribute_identifier_size_class_vertical = 21,
     car_attribute_identifier_memory_class = 22,
     car_attribute_identifier_graphics_class = 23,
+    car_attribute_identifier_display_gamut = 24,
+    car_attribute_identifier_deployment_target = 25,
 
     /* Not a real value; used as a marker for the maximum identifier. */
-    _car_attribute_identifier_count = 24,
+    _car_attribute_identifier_count = 26,
 };
 
 enum car_attribute_identifier_size_value {
@@ -195,6 +197,11 @@ struct car_header {
     uint32_t color_space_id; // 01 00 00 00
     uint32_t key_semantics; // 01 00 00 00
 } __attribute__((packed));
+
+struct car_extended_metadata {
+    char magic[4]; // 'META'
+    char contents[1024]; // string
+};
 
 struct car_key_format {
     char magic[4]; // 'kfmt'
@@ -297,6 +304,7 @@ enum car_rendition_value_layout {
     car_rendition_value_layout_nine_part_scale = 31,
     car_rendition_value_layout_nine_part_horizontal_uniform_vertical_scale = 32,
     car_rendition_value_layout_nine_part_horizontal_scale_vertical_uniform = 33,
+    car_rendition_value_layout_nine_part_edges_only = 34,
     car_rendition_value_layout_six_part = 40,
     car_rendition_value_layout_animation_filmstrip = 50,
 
@@ -420,9 +428,15 @@ enum car_rendition_data_compression_magic {
 extern const char *const car_header_variable;
 extern const char *const car_key_format_variable;
 extern const char *const car_facet_keys_variable;
+extern const char *const car_renditions_variable;
+
+extern const char *const car_extended_metadata_variable;
+extern const char *const car_bitmap_keys_variable;
+extern const char *const car_globals_variable;
+extern const char *const car_external_keys_variable;
+
 extern const char *const car_part_info_variable;
 extern const char *const car_element_info_variable;
-extern const char *const car_renditions_variable;
 extern const char *const car_colors_variable;
 extern const char *const car_fonts_variable;
 extern const char *const car_font_sizes_variable;

--- a/Libraries/libcar/Sources/Reader.cpp
+++ b/Libraries/libcar/Sources/Reader.cpp
@@ -125,6 +125,13 @@ dump() const
     printf("Key Semantics: %x\n", header->key_semantics);
     printf("\n");
 
+    int extended_metadata_index = bom_variable_get(_bom.get(), car_extended_metadata_variable);
+    if (extended_metadata_index != -1) {
+        struct car_extended_metadata *extended = (struct car_extended_metadata *)bom_index_get(_bom.get(), extended_metadata_index, NULL);
+        printf("Extended metadata: %s\n", extended->contents);
+        printf("\n");
+    }
+
     int key_format_index = bom_variable_get(_bom.get(), car_key_format_variable);
     struct car_key_format *keyfmt = (struct car_key_format *)bom_index_get(_bom.get(), key_format_index, NULL);
 

--- a/Libraries/libcar/Sources/Rendition.cpp
+++ b/Libraries/libcar/Sources/Rendition.cpp
@@ -130,7 +130,7 @@ static ext::optional<std::vector<uint8_t>> Encode(Rendition const *rendition, ex
 static Rendition::ResizeMode
 ResizeModeFromLayout(enum car_rendition_value_layout layout)
 {
-    switch(layout) {
+    switch (layout) {
         case car_rendition_value_layout_one_part_fixed_size:
         case car_rendition_value_layout_three_part_horizontal_uniform:
         case car_rendition_value_layout_three_part_vertical_uniform:
@@ -149,6 +149,7 @@ ResizeModeFromLayout(enum car_rendition_value_layout layout)
             return Rendition::ResizeMode::HorizontalUniformVerticalScale;
         case car_rendition_value_layout_nine_part_horizontal_scale_vertical_uniform:
             return Rendition::ResizeMode::HorizontalScaleVerticalUniform;
+        case car_rendition_value_layout_nine_part_edges_only:
         case car_rendition_value_layout_six_part:
         case car_rendition_value_layout_gradient:
         case car_rendition_value_layout_effect:
@@ -317,7 +318,7 @@ Decode(struct car_rendition_value *value)
     struct car_rendition_data_header1 *header1 = (struct car_rendition_data_header1 *)((uintptr_t)value + sizeof(struct car_rendition_value) + value->info_len);
 
     if (strncmp(header1->magic, "MLEC", sizeof(header1->magic)) != 0) {
-        fprintf(stderr, "error: header1 magic is wrong, can't possibly decode\n");
+        fprintf(stderr, "error: header1 magic is wrong (%.4s), can't possibly decode\n", header1->magic);
         return ext::nullopt;
     }
 

--- a/Libraries/libcar/Sources/car_format.c
+++ b/Libraries/libcar/Sources/car_format.c
@@ -12,9 +12,15 @@
 const char *const car_header_variable = "CARHEADER";
 const char *const car_key_format_variable = "KEYFORMAT";
 const char *const car_facet_keys_variable = "FACETKEYS";
+const char *const car_renditions_variable = "RENDITIONS";
+
+const char *const car_extended_metadata_variable = "EXTENDED_METADATA";
+const char *const car_bitmap_keys_variable = "BITMAPKEYS";
+const char *const car_globals_variable = "CARGLOBALS";
+const char *const car_external_keys_variable = "EXTERNAL_KEYS";
+
 const char *const car_part_info_variable = "PART_INFO";
 const char *const car_element_info_variable = "ELEMENT_INFO";
-const char *const car_renditions_variable = "RENDITIONS";
 const char *const car_colors_variable = "COLORS";
 const char *const car_fonts_variable = "FONTS";
 const char *const car_font_sizes_variable = "FONTSIZES";
@@ -42,5 +48,7 @@ const char *const car_attribute_identifier_names[_car_attribute_identifier_count
     [car_attribute_identifier_size_class_vertical] = "size_class_vertical",
     [car_attribute_identifier_memory_class] = "memory_class",
     [car_attribute_identifier_graphics_class] = "graphics_class",
+    [car_attribute_identifier_display_gamut] = "display_gamut",
+    [car_attribute_identifier_deployment_target] = "deployment_target",
 };
 


### PR DESCRIPTION
The extra metadata section stores a string with contextual info
on how the asset archive was compiled, especially when the archive
is stripped to target certain devices or platforms.

Other new fields correspond to new asset document format fields.