### PR TITLE
[actool] Fix car header key format in car writer

### DIFF
--- a/Libraries/libcar/Headers/car/car_format.h
+++ b/Libraries/libcar/Headers/car/car_format.h
@@ -197,7 +197,7 @@ struct car_header {
 } __attribute__((packed));
 
 struct car_key_format {
-    char magic[4]; // 'kfmt'
+    char magic[4]; // 'tmfk'
     uint32_t reserved;
     uint32_t num_identifiers;
     uint32_t identifier_list[0];

--- a/Libraries/libcar/Sources/Writer.cpp
+++ b/Libraries/libcar/Sources/Writer.cpp
@@ -127,7 +127,7 @@ write() const
       std::vector<enum car_attribute_identifier> format = DetermineKeyFormat(_facets, _renditions);
       keyfmt_size = sizeof(struct car_key_format) + (format.size() * sizeof(uint32_t));
       keyfmt = (struct car_key_format *)malloc(keyfmt_size);
-      strncpy(keyfmt->magic, "kfmt", 4);
+      strncpy(keyfmt->magic, "tmfk", 4);
       keyfmt->reserved = 0;
       keyfmt->num_identifiers = format.size();
       for (size_t i = 0; i < format.size(); ++i) {


### PR DESCRIPTION
Looks like the key format is also little-endian.

Fixes the issue:
```
CoreUI:  Car file has erroneous key format information. Using CUISystemThemeRenditionKeyFormat
```
as well as the subsequent buffer overflow when reading the compiled car file.