### PR TITLE
Support Info.plist in Toolchains

### DIFF
--- a/Libraries/xcsdk/Sources/SDK/Toolchain.cpp
+++ b/Libraries/xcsdk/Sources/SDK/Toolchain.cpp
@@ -55,7 +55,10 @@ Open(Filesystem const *filesystem, std::shared_ptr<Manager> manager, std::string
 
     std::string settingsFileName = path + "/ToolchainInfo.plist";
     if (!filesystem->isReadable(settingsFileName)) {
-        return nullptr;
+        settingsFileName = path + "/Info.plist";
+        if (!filesystem->isReadable(settingsFileName)) {
+            return nullptr;
+        }
     }
 
     std::string realPath = filesystem->resolvePath(settingsFileName);


### PR DESCRIPTION
Alternative keychains such as the Swift nightly use an updated plist file, renamed to Info.plist.