### PR TITLE
Modernize and complete SDK loading.

### DIFF
--- a/Libraries/builtin/Sources/infoPlistUtility/Driver.cpp
+++ b/Libraries/builtin/Sources/infoPlistUtility/Driver.cpp
@@ -97,6 +97,8 @@ ExpandBuildSettings(plist::Object *value, pbxsetting::Environment const &environ
 static void
 AddBuildEnvironment(plist::Dictionary *root, pbxsetting::Environment const &environment)
 {
+    // TODO: This should use `xcsdk::SDK::Platform::additionalInfo()`.
+
     root->set("DTCompiler", plist::String::New(environment.resolve("DEFAULT_COMPILER")));
     root->set("DTXcode", plist::String::New(environment.resolve("XCODE_VERSION_ACTUAL")));
     root->set("DTXcodeBuild", plist::String::New(environment.resolve("XCODE_PRODUCT_BUILD_VERSION")));

--- a/Libraries/pbxbuild/Sources/Target/Environment.cpp
+++ b/Libraries/pbxbuild/Sources/Target/Environment.cpp
@@ -384,13 +384,21 @@ Create(Build::Environment const &buildEnvironment, Build::Context const &buildCo
         pbxsetting::Setting::Parse("GCC_VERSION", "$(DEFAULT_COMPILER)"),
     }), false);
 
-    environment.insertFront(sdk->platform()->defaultProperties(), false);
+    if (sdk->platform()->defaultProperties()) {
+        environment.insertFront(*sdk->platform()->defaultProperties(), false);
+    }
     environment.insertFront(PlatformArchitecturesLevel(buildEnvironment.specManager(), specDomains), false);
-    environment.insertFront(sdk->defaultProperties(), false);
+    if (sdk->defaultProperties()) {
+        environment.insertFront(*sdk->defaultProperties(), false);
+    }
     environment.insertFront(sdk->platform()->settings(), false);
     environment.insertFront(sdk->settings(), false);
-    environment.insertFront(sdk->customProperties(), false);
-    environment.insertFront(sdk->platform()->overrideProperties(), false);
+    if (sdk->customProperties()) {
+        environment.insertFront(*sdk->customProperties(), false);
+    }
+    if (sdk->platform()->overrideProperties()) {
+        environment.insertFront(*sdk->platform()->overrideProperties(), false);
+    }
 
     if (packageType != nullptr) {
         environment.insertFront(PackageTypeLevel(packageType), false);
@@ -435,6 +443,7 @@ Create(Build::Environment const &buildEnvironment, Build::Context const &buildCo
     std::vector<xcsdk::SDK::Toolchain::shared_ptr> toolchains;
     for (std::string const &toolchainName : pbxsetting::Type::ParseList(environment.resolve("TOOLCHAINS"))) {
         if (xcsdk::SDK::Toolchain::shared_ptr toolchain = buildEnvironment.sdkManager()->findToolchain(toolchainName)) {
+            // TODO: Apply toolchain override build settings.
             toolchains.push_back(toolchain);
         }
     }

--- a/Libraries/plist/Sources/String.cpp
+++ b/Libraries/plist/Sources/String.cpp
@@ -9,6 +9,7 @@
 
 #include <plist/String.h>
 #include <plist/Boolean.h>
+#include <plist/Date.h>
 #include <plist/Real.h>
 #include <plist/Integer.h>
 
@@ -52,6 +53,8 @@ Coerce(Object const *obj)
         return String::New(std::to_string(integer->value()));
     } else if (Boolean const *boolean = CastTo<Boolean>(obj)) {
         return String::New(boolean->value() ? "YES" : "NO");
+    } else if (Date const *date = CastTo<Date>(obj)) {
+        return String::New(date->stringValue());
     }
 
     return nullptr;

--- a/Libraries/xcdriver/Sources/ShowSDKsAction.cpp
+++ b/Libraries/xcdriver/Sources/ShowSDKsAction.cpp
@@ -48,9 +48,9 @@ Run(process::Context const *processContext, Filesystem const *filesystem, Option
     }
 
     for (auto const &platform : manager->platforms()) {
-        printf("%s SDKs:\n", platform->description().c_str());
+        printf("%s SDKs:\n", platform->description().value_or(platform->name()).c_str());
         for (auto const &target : platform->targets()) {
-            printf("\t%-32s-sdk %s\n", target->displayName().c_str(), target->canonicalName().c_str());
+            printf("\t%-32s-sdk %s\n", target->displayName().value_or(target->bundleName()).c_str(), target->canonicalName().value_or(target->bundleName()).c_str());
         }
         printf("\n");
     }

--- a/Libraries/xcdriver/Sources/VersionAction.cpp
+++ b/Libraries/xcdriver/Sources/VersionAction.cpp
@@ -62,31 +62,31 @@ Run(process::Context const *processContext, Filesystem const *filesystem, Option
 
         printf("%s - %s (%s)\n",
                 target->bundleName().c_str(),
-                target->displayName().c_str(),
-                target->canonicalName().c_str());
-        if (!target->version().empty()) {
-            printf("SDKVersion: %s\n", target->version().c_str());
+                target->displayName().value_or(target->bundleName()).c_str(),
+                target->canonicalName().value_or(target->bundleName()).c_str());
+        if (target->version()) {
+            printf("SDKVersion: %s\n", target->version()->c_str());
         }
         printf("Path: %s\n", target->path().c_str());
-        if (!target->platform()->version().empty()) {
-            printf("PlatformVersion: %s\n", target->platform()->version().c_str());
+        if (target->platform()->version()) {
+            printf("PlatformVersion: %s\n", target->platform()->version()->c_str());
         }
         printf("PlatformPath: %s\n", target->platform()->path().c_str());
         if (auto product = target->product()) {
-            if (!product->buildVersion().empty()) {
-                printf("ProductBuildVersion: %s\n", product->buildVersion().c_str());
+            if (product->buildVersion()) {
+                printf("ProductBuildVersion: %s\n", product->buildVersion()->c_str());
             }
-            if (!product->copyright().empty()) {
-                printf("ProductCopyright: %s\n", product->copyright().c_str());
+            if (product->copyright()) {
+                printf("ProductCopyright: %s\n", product->copyright()->c_str());
             }
-            if (!product->name().empty()) {
-                printf("ProductName: %s\n", product->name().c_str());
+            if (product->name()) {
+                printf("ProductName: %s\n", product->name()->c_str());
             }
-            if (!product->userVisibleVersion().empty()) {
-                printf("ProductUserVisibleVersion: %s\n", product->userVisibleVersion().c_str());
+            if (product->userVisibleVersion()) {
+                printf("ProductUserVisibleVersion: %s\n", product->userVisibleVersion()->c_str());
             }
-            if (!product->version().empty()) {
-                printf("ProductVersion: %s\n", product->version().c_str());
+            if (product->version()) {
+                printf("ProductVersion: %s\n", product->version()->c_str());
             }
         }
         printf("\n");

--- a/Libraries/xcsdk/Headers/xcsdk/SDK/Platform.h
+++ b/Libraries/xcsdk/Headers/xcsdk/SDK/Platform.h
@@ -29,21 +29,37 @@ public:
     typedef std::vector <shared_ptr> vector;
 
 private:
-    std::weak_ptr<Manager>          _manager;
-    PlatformVersion::shared_ptr     _platformVersion;
-    std::vector<Target::shared_ptr> _targets;
-    std::string                     _path;
-    std::string                     _identifier;
-    std::string                     _name;
-    std::string                     _description;
-    std::string                     _type;
-    std::string                     _version;
-    std::string                     _familyIdentifier;
-    std::string                     _familyName;
-    std::string                     _icon;
-    plist::Dictionary              *_defaultDebuggerSettings;
-    pbxsetting::Level               _defaultProperties;
-    pbxsetting::Level               _overrideProperties;
+    std::weak_ptr<Manager>           _manager;
+    PlatformVersion::shared_ptr      _platformVersion;
+    std::vector<Target::shared_ptr>  _targets;
+
+private:
+    std::string                      _path;
+    std::string                      _name;
+
+private:
+    ext::optional<std::string>       _identifier;
+    ext::optional<std::string>       _description;
+    ext::optional<std::string>       _type;
+    ext::optional<std::string>       _icon;
+    ext::optional<std::string>       _version;
+
+private:
+    ext::optional<std::string>       _familyIdentifier;
+    ext::optional<std::string>       _familyName;
+
+private:
+    ext::optional<pbxsetting::Level> _defaultProperties;
+    ext::optional<pbxsetting::Level> _overrideProperties;
+
+private:
+    ext::optional<pbxsetting::Level> _additionalInfo;
+    ext::optional<std::string>       _minimumSDKVersion;
+
+private:
+    ext::optional<bool>              _isDeploymentPlatform;
+    plist::Dictionary         const *_defaultDebuggerSettings;
+    ext::optional<std::string>       _runtimeSystemSpecification;
 
 public:
     Platform();
@@ -62,36 +78,48 @@ public:
 public:
     inline std::string const &path() const
     { return _path; }
-
-public:
-    inline std::string const &identifier() const
-    { return _identifier; }
     inline std::string const &name() const
     { return _name; }
-    inline std::string const &description() const
+
+public:
+    inline ext::optional<std::string> const &identifier() const
+    { return _identifier; }
+    inline ext::optional<std::string> const &description() const
     { return _description; }
-    inline std::string const &version() const
+    inline ext::optional<std::string> const &version() const
     { return _version; }
-    inline std::string const &type() const
+    inline ext::optional<std::string> const &icon() const
+    { return _icon; }
+    inline ext::optional<std::string> const &type() const
     { return _type; }
 
 public:
-    inline std::string const familyIdentifier() const
+    inline ext::optional<std::string> const familyIdentifier() const
     { return _familyIdentifier; }
-    inline std::string const familyName() const
+    inline ext::optional<std::string> const familyName() const
     { return _familyName; }
 
 public:
-    inline plist::Dictionary const *defaultDebuggerSettings() const
-    { return _defaultDebuggerSettings; }
-    inline pbxsetting::Level const &defaultProperties() const
+    inline ext::optional<pbxsetting::Level> const &defaultProperties() const
     { return _defaultProperties; }
-    inline pbxsetting::Level const &overrideProperties() const
+    inline ext::optional<pbxsetting::Level> const &overrideProperties() const
     { return _overrideProperties; }
 
 public:
-    inline std::string const &icon() const
-    { return _icon; }
+    inline ext::optional<pbxsetting::Level> const &additionalInfo() const
+    { return _additionalInfo; }
+    inline ext::optional<std::string> const &minimumSDKVersion() const
+    { return _minimumSDKVersion; }
+
+public:
+    inline bool isDeploymentPlatform() const
+    { return _isDeploymentPlatform.value_or(false); }
+    inline ext::optional<bool> const &isDeploymentPlatformOptional() const
+    { return _isDeploymentPlatform; }
+    inline plist::Dictionary const *defaultDebuggerSettings() const
+    { return _defaultDebuggerSettings; }
+    inline ext::optional<std::string> const &runtimeSystemSpecification() const
+    { return _runtimeSystemSpecification; }
 
 public:
     pbxsetting::Level settings() const;

--- a/Libraries/xcsdk/Headers/xcsdk/SDK/PlatformVersion.h
+++ b/Libraries/xcsdk/Headers/xcsdk/SDK/PlatformVersion.h
@@ -12,6 +12,7 @@
 
 #include <memory>
 #include <string>
+#include <ext/optional>
 
 namespace libutil { class Filesystem; };
 namespace plist { class Dictionary; }
@@ -23,23 +24,29 @@ public:
     typedef std::shared_ptr <PlatformVersion> shared_ptr;
 
 private:
-    std::string _projectName;
-    std::string _productBuildVersion;
-    std::string _buildVersion;
-    std::string _sourceVersion;
+    ext::optional<std::string> _projectName;
+    ext::optional<std::string> _productBuildVersion;
+    ext::optional<std::string> _buildVersion;
+    ext::optional<std::string> _sourceVersion;
+    ext::optional<std::string> _bundleShortVersionString;
+    ext::optional<std::string> _bundleVersion;
 
 public:
     PlatformVersion();
 
 public:
-    inline std::string const &name() const
+    inline ext::optional<std::string> const &projectName() const
     { return _projectName; }
-    inline std::string const &version() const
+    inline ext::optional<std::string> const &projectBuildVersion() const
     { return _productBuildVersion; }
-    inline std::string const &buildVersion() const
+    inline ext::optional<std::string> const &buildVersion() const
     { return _buildVersion; }
-    inline std::string const &sourceVersion() const
+    inline ext::optional<std::string> const &sourceVersion() const
     { return _sourceVersion; }
+    inline ext::optional<std::string> const &bundleShortVersionString() const
+    { return _bundleShortVersionString; }
+    inline ext::optional<std::string> const &bundleVersion() const
+    { return _bundleVersion; }
 
 public:
     static PlatformVersion::shared_ptr Open(libutil::Filesystem const *filesystem, std::string const &path);

--- a/Libraries/xcsdk/Headers/xcsdk/SDK/Product.h
+++ b/Libraries/xcsdk/Headers/xcsdk/SDK/Product.h
@@ -12,6 +12,7 @@
 
 #include <memory>
 #include <string>
+#include <ext/optional>
 
 namespace libutil { class Filesystem; };
 namespace plist { class Dictionary; }
@@ -23,25 +24,25 @@ public:
     typedef std::shared_ptr <Product> shared_ptr;
 
 private:
-    std::string _productName;
-    std::string _productVersion;
-    std::string _productUserVisibleVersion;
-    std::string _productBuildVersion;
-    std::string _productCopyright;
+    ext::optional<std::string> _productName;
+    ext::optional<std::string> _productVersion;
+    ext::optional<std::string> _productUserVisibleVersion;
+    ext::optional<std::string> _productBuildVersion;
+    ext::optional<std::string> _productCopyright;
 
 public:
     Product();
 
 public:
-    inline std::string const &name() const
+    inline ext::optional<std::string> const &name() const
     { return _productName; }
-    inline std::string const &version() const
+    inline ext::optional<std::string> const &version() const
     { return _productVersion; }
-    inline std::string const &userVisibleVersion() const
+    inline ext::optional<std::string> const &userVisibleVersion() const
     { return _productUserVisibleVersion; }
-    inline std::string const &buildVersion() const
+    inline ext::optional<std::string> const &buildVersion() const
     { return _productBuildVersion; }
-    inline std::string const &copyright() const
+    inline ext::optional<std::string> const &copyright() const
     { return _productCopyright; }
 
 public:

--- a/Libraries/xcsdk/Headers/xcsdk/SDK/Target.h
+++ b/Libraries/xcsdk/Headers/xcsdk/SDK/Target.h
@@ -32,23 +32,38 @@ public:
     typedef std::shared_ptr <Target> shared_ptr;
 
 private:
-    std::weak_ptr<Manager>             _manager;
-    std::weak_ptr<Platform>            _platform;
+    std::weak_ptr<Manager>                  _manager;
+    std::weak_ptr<Platform>                 _platform;
 
 private:
-    Product::shared_ptr                _product;
-    std::string                        _path;
-    std::string                        _bundleName;
-    std::string                        _version;
-    std::string                        _canonicalName;
-    std::string                        _displayName;
-    std::string                        _minimalDisplayName;
-    std::string                        _maximumDeploymentTarget;
-    std::vector<std::string>           _supportedBuildToolsVersion;
-    pbxsetting::Level                  _customProperties;
-    pbxsetting::Level                  _defaultProperties;
-    bool                               _isBaseSDK;
-    std::vector<Toolchain::shared_ptr> _toolchains;
+    Product::shared_ptr                     _product;
+    std::vector<Toolchain::shared_ptr>      _toolchains;
+
+private:
+    std::string                             _path;
+    std::string                             _bundleName;
+
+private:
+    ext::optional<std::string>              _canonicalName;
+    ext::optional<std::string>              _displayName;
+    ext::optional<std::string>              _minimalDisplayName;
+    ext::optional<std::string>              _version;
+
+private:
+    ext::optional<bool>                     _isBaseSDK;
+    ext::optional<std::string>              _defaultDeploymentTarget;
+    ext::optional<std::string>              _maximumDeploymentTarget;
+    ext::optional<pbxsetting::Level>        _defaultProperties;
+    ext::optional<pbxsetting::Level>        _customProperties;
+    ext::optional<std::vector<std::string>> _propertyConditionFallbackNames;
+
+private:
+    ext::optional<std::string>              _docSetFeedName;
+    ext::optional<std::string>              _docSetFeedURL;
+
+private:
+    ext::optional<std::string>              _minimumSupportedToolsVersion;
+    ext::optional<std::vector<std::string>> _supportedBuildToolComponents;
 
 public:
     Target();
@@ -61,54 +76,54 @@ public:
     { return _platform.lock(); }
 
 public:
+    inline Product::shared_ptr const &product() const
+    { return _product; }
+    inline std::vector<Toolchain::shared_ptr> const &toolchains() const
+    { return _toolchains; }
+
+public:
     inline std::string const &path() const
     { return _path; }
     inline std::string const &bundleName() const
     { return _bundleName; }
 
 public:
-    inline Product::shared_ptr const &product() const
-    { return _product; }
-
-public:
-    inline std::string const &version() const
+    inline ext::optional<std::string> const &canonicalName() const
+    { return _canonicalName; }
+    inline ext::optional<std::string> const &displayName() const
+    { return _displayName; }
+    inline ext::optional<std::string> const &minimalDisplayName() const
+    { return _minimalDisplayName; }
+    inline ext::optional<std::string> const &version() const
     { return _version; }
 
 public:
-    inline std::string const &canonicalName() const
-    { return _canonicalName; }
-
-public:
-    inline std::string const &displayName() const
-    { return _displayName; }
-
-    inline std::string const &minimalDisplayName() const
-    { return _minimalDisplayName; }
-
-public:
-    inline std::string const &maximumDeploymentTarget() const
-    { return _maximumDeploymentTarget; }
-
-public:
-    inline std::vector<std::string> const &supportedBuildToolsVersion() const
-    { return _supportedBuildToolsVersion; }
-    inline std::vector<std::string> &supportedBuildToolsVersion()
-    { return _supportedBuildToolsVersion; }
-
-public:
-    inline pbxsetting::Level const &customProperties() const
-    { return _customProperties; }
-
-    inline pbxsetting::Level const &defaultProperties() const
-    { return _defaultProperties; }
-
-public:
     inline bool isBaseSDK() const
+    { return _isBaseSDK.value_or(false); }
+    inline ext::optional<bool> isBaseSDKOptional() const
     { return _isBaseSDK; }
+    inline ext::optional<std::string> const &defaultDeploymentTarget() const
+    { return _defaultDeploymentTarget; }
+    inline ext::optional<std::string> const &maximumDeploymentTarget() const
+    { return _maximumDeploymentTarget; }
+    inline ext::optional<pbxsetting::Level> const &defaultProperties() const
+    { return _defaultProperties; }
+    inline ext::optional<pbxsetting::Level> const &customProperties() const
+    { return _customProperties; }
+    inline ext::optional<std::vector<std::string>> const &propertyConditionFallbackNames()
+    { return _propertyConditionFallbackNames; }
 
 public:
-    inline std::vector<Toolchain::shared_ptr> const &toolchains() const
-    { return _toolchains; }
+    inline ext::optional<std::string> const &docSetFeedName()
+    { return _docSetFeedName; }
+    inline ext::optional<std::string> const &docSetFeedURL()
+    { return _docSetFeedURL; }
+
+public:
+    inline ext::optional<std::string> const &minimumSupportedToolsVersion()
+    { return _minimumSupportedToolsVersion; }
+    inline ext::optional<std::vector<std::string>> &supportedBuildToolComponents()
+    { return _supportedBuildToolComponents; }
 
 public:
     pbxsetting::Level settings(void) const;

--- a/Libraries/xcsdk/Headers/xcsdk/SDK/Toolchain.h
+++ b/Libraries/xcsdk/Headers/xcsdk/SDK/Toolchain.h
@@ -10,9 +10,12 @@
 #ifndef __xcsdk_SDK_Toolchain_h
 #define __xcsdk_SDK_Toolchain_h
 
+#include <pbxsetting/Level.h>
+
 #include <memory>
 #include <string>
 #include <vector>
+#include <ext/optional>
 
 namespace libutil { class Filesystem; };
 namespace plist { class Dictionary; }
@@ -26,9 +29,28 @@ public:
     typedef std::shared_ptr <Toolchain> shared_ptr;
 
 private:
-    std::string _path;
-    std::string _name;
-    std::string _identifier;
+    std::string                             _path;
+    std::string                             _name;
+
+private:
+    ext::optional<std::string>              _identifier;
+    ext::optional<std::vector<std::string>> _aliases;
+
+public:
+    ext::optional<std::string>              _displayName;
+    ext::optional<std::string>              _shortDisplayName;
+    ext::optional<std::string>              _createdDate;
+    ext::optional<std::string>              _reportProblemURL;
+
+public:
+    ext::optional<std::string>              _bundleIdentifier;
+    ext::optional<std::string>              _version;
+    ext::optional<int>                      _compatibilityVersion;
+    ext::optional<std::string>              _compatibilityVersionDisplayString;
+
+public:
+    ext::optional<bool>                     _providesSwiftVersion;
+    ext::optional<pbxsetting::Level>        _overrideBuildSettings;
 
 public:
     Toolchain();
@@ -37,12 +59,42 @@ public:
 public:
     inline std::string const &path() const
     { return _path; }
-
-public:
     inline std::string const &name() const
     { return _name; }
-    inline std::string const &identifier() const
+
+public:
+    inline ext::optional<std::string> const &identifier() const
     { return _identifier; }
+    inline ext::optional<std::vector<std::string>> const &aliases() const
+    { return _aliases; }
+
+public:
+    inline ext::optional<std::string> const &displayName() const
+    { return _displayName; }
+    inline ext::optional<std::string> const &shortDisplayName() const
+    { return _shortDisplayName; }
+    inline ext::optional<std::string> const &createdDate() const
+    { return _createdDate; }
+    inline ext::optional<std::string> const &reportProblemURL() const
+    { return _reportProblemURL; }
+
+public:
+    inline ext::optional<std::string> const &bundleIdentifier() const
+    { return _bundleIdentifier; }
+    inline ext::optional<std::string> const &version() const
+    { return _version; }
+    inline ext::optional<int> const &compatibilityVersion() const
+    { return _compatibilityVersion; }
+    inline ext::optional<std::string> const &compatibilityVersionDisplayString() const
+    { return _compatibilityVersionDisplayString; }
+
+public:
+    inline bool providesSwiftVersion() const
+    { return _providesSwiftVersion.value_or(false); }
+    inline ext::optional<bool> const &providesSwiftVersionOptional() const
+    { return _providesSwiftVersion; }
+    inline ext::optional<pbxsetting::Level> const &overrideBuildSettings() const
+    { return _overrideBuildSettings; }
 
 public:
     std::vector<std::string> executablePaths() const;

--- a/Libraries/xcsdk/Sources/Configuration.cpp
+++ b/Libraries/xcsdk/Sources/Configuration.cpp
@@ -36,8 +36,8 @@ DefaultPaths(process::Context const *processContext)
     if (ext::optional<std::string> environmentPath = processContext->environmentVariable("XCSDK_CONFIGURATION_PATH")) {
         defaultPaths.push_back(*environmentPath);
     } else {
-        ext::optional<std::string> homePath = processContext->environmentVariable("HOME");
-        if (getuid() != 0 && homePath) {
+        ext::optional<std::string> homePath = processContext->userHomeDirectory();
+        if (homePath) {
             defaultPaths.push_back(*homePath + "/.xcsdk/xcsdk_configuration.plist");
         }
         defaultPaths.push_back("/var/db/xcsdk_configuration.plist");

--- a/Libraries/xcsdk/Sources/SDK/Toolchain.cpp
+++ b/Libraries/xcsdk/Sources/SDK/Toolchain.cpp
@@ -10,8 +10,12 @@
 #include <xcsdk/SDK/Toolchain.h>
 #include <libutil/Filesystem.h>
 #include <libutil/FSUtil.h>
+#include <plist/Array.h>
+#include <plist/Boolean.h>
 #include <plist/Dictionary.h>
+#include <plist/Integer.h>
 #include <plist/String.h>
+#include <plist/Keys/Unpack.h>
 #include <plist/Format/Any.h>
 
 using xcsdk::SDK::Toolchain;
@@ -37,10 +41,87 @@ executablePaths() const
 bool Toolchain::
 parse(plist::Dictionary const *dict)
 {
-    auto I = dict->value <plist::String> ("Identifier");
+    std::unordered_set<std::string> seen;
+    auto unpack = plist::Keys::Unpack("Toolchain", dict, &seen);
+
+    auto I    = unpack.cast <plist::String> ("Identifier");
+    auto As   = unpack.cast <plist::Array> ("Aliases");
+    auto DN   = unpack.cast <plist::String> ("DisplayName");
+    auto SDN  = unpack.cast <plist::String> ("ShortDisplayName");
+    auto CD   = unpack.coerce <plist::String> ("CreatedDate"); /* From plist::Date. */
+    auto RPU  = unpack.cast <plist::String> ("ReportProblemURL");
+    auto CFBI = unpack.cast <plist::String> ("CFBundleIdentifier");
+    auto V    = unpack.cast <plist::String> ("Version");
+    auto CV   = unpack.coerce <plist::Integer> ("CompatibilityVersion");
+    auto CVDS = unpack.cast <plist::String> ("CompatibilityVersionDisplayString");
+    auto PSV  = unpack.coerce <plist::Boolean> ("ProvidesSwiftVersion");
+    auto OBS  = unpack.cast <plist::Dictionary> ("OverrideBuildSettings");
+
+    if (!unpack.complete(true)) {
+        fprintf(stderr, "%s", unpack.errorText().c_str());
+    }
 
     if (I != nullptr) {
         _identifier = I->value();
+    }
+
+    if (As != nullptr) {
+        _aliases = std::vector<std::string>();
+        for (size_t n = 0; n < As->count(); n++) {
+            if (auto A = As->value<plist::String>(n)) {
+                _aliases->push_back(A->value());
+            }
+        }
+    }
+
+    if (DN != nullptr) {
+        _displayName = DN->value();
+    }
+
+    if (SDN != nullptr) {
+        _shortDisplayName = SDN->value();
+    }
+
+    if (CD != nullptr) {
+        _createdDate = CD->value();
+    }
+
+    if (RPU != nullptr) {
+        _reportProblemURL = RPU->value();
+    }
+
+    if (CFBI != nullptr) {
+        _bundleIdentifier = CFBI->value();
+    }
+
+    if (V != nullptr) {
+        _version = V->value();
+    }
+
+    if (CV != nullptr) {
+        _compatibilityVersion = CV->value();
+    }
+
+    if (CVDS != nullptr) {
+        _compatibilityVersionDisplayString = CVDS->value();
+    }
+
+    if (PSV != nullptr) {
+        _providesSwiftVersion = PSV->value();
+    }
+
+    if (OBS != nullptr) {
+        std::vector<pbxsetting::Setting> settings;
+        for (size_t n = 0; n < OBS->count(); n++) {
+            auto OBSK = OBS->key(n);
+            auto OBSV = OBS->value <plist::String> (OBSK);
+
+            if (OBSV != nullptr) {
+                pbxsetting::Setting setting = pbxsetting::Setting::Parse(OBSK, OBSV->value());
+                settings.push_back(setting);
+            }
+        }
+        _overrideBuildSettings = pbxsetting::Level(settings);
     }
 
     return true;
@@ -53,6 +134,9 @@ Open(Filesystem const *filesystem, std::string const &path)
         return nullptr;
     }
 
+    /*
+     * Read toolchain info.
+     */
     std::string settingsFileName = path + "/ToolchainInfo.plist";
     if (!filesystem->isReadable(settingsFileName)) {
         settingsFileName = path + "/Info.plist";
@@ -71,9 +155,9 @@ Open(Filesystem const *filesystem, std::string const &path)
         return nullptr;
     }
 
-    //
-    // Parse property list
-    //
+    /*
+     * Parse property list.
+     */
     auto result = plist::Format::Any::Deserialize(contents);
     if (result.first == nullptr) {
         return nullptr;
@@ -84,19 +168,19 @@ Open(Filesystem const *filesystem, std::string const &path)
         return nullptr;
     }
 
-    //
-    // Parse the toolchain dictionary and create the object.
-    //
+    /*
+     * Create the toolchain object.
+     */
     auto toolchain = std::make_shared<Toolchain>();
+    toolchain->_path = FSUtil::GetDirectoryName(realPath);
+    toolchain->_name = FSUtil::GetBaseNameWithoutExtension(toolchain->_path);
+
+    /*
+     * Parse the toolchain dictionary.
+     */
     if (!toolchain->parse(plist)) {
         return nullptr;
     }
-
-    //
-    // Save some useful info
-    //
-    toolchain->_path = FSUtil::GetDirectoryName(realPath);
-    toolchain->_name = FSUtil::GetBaseNameWithoutExtension(toolchain->_path);
 
     return toolchain;
 }

--- a/Libraries/xcsdk/Tests/test_Manager.cpp
+++ b/Libraries/xcsdk/Tests/test_Manager.cpp
@@ -52,10 +52,10 @@ TEST(Manager, ConfigurationExtraPaths)
 
     ASSERT_EQ(manager->platforms().size(), 1);
     Platform::shared_ptr const &platform = manager->platforms().front();
-    EXPECT_EQ(platform->identifier(), "extra");
+    EXPECT_EQ(platform->identifier(), std::string("extra"));
     EXPECT_EQ(platform->name(), "Extra");
 
     ASSERT_EQ(manager->toolchains().size(), 1);
     Toolchain::shared_ptr const &toolchain = manager->toolchains().front();
-    EXPECT_EQ(toolchain->identifier(), "extra");
+    EXPECT_EQ(toolchain->identifier(), std::string("extra"));
 }

--- a/Libraries/xcsdk/Tests/test_PlatformVersion.cpp
+++ b/Libraries/xcsdk/Tests/test_PlatformVersion.cpp
@@ -37,8 +37,8 @@ TEST(PlatformVersion, Parse)
     auto platformVersion = PlatformVersion::Open(&filesystem, "/" + platform);
     ASSERT_NE(platformVersion, nullptr);
 
-    EXPECT_EQ(platformVersion->name(), "Name");
-    EXPECT_EQ(platformVersion->version(), "1");
-    EXPECT_EQ(platformVersion->buildVersion(), "10");
-    EXPECT_EQ(platformVersion->sourceVersion(), "100");
+    EXPECT_EQ(platformVersion->projectName(), std::string("Name"));
+    EXPECT_EQ(platformVersion->projectBuildVersion(), std::string("1"));
+    EXPECT_EQ(platformVersion->buildVersion(), std::string("10"));
+    EXPECT_EQ(platformVersion->sourceVersion(), std::string("100"));
 }

--- a/Libraries/xcsdk/Tools/xcrun.cpp
+++ b/Libraries/xcsdk/Tools/xcrun.cpp
@@ -314,7 +314,7 @@ static int Run(Filesystem *filesystem, process::Context const *processContext, p
         if (target == nullptr) {
             fprintf(stderr, "verbose: not using any SDK\n");
         } else {
-            fprintf(stderr, "verbose: using sdk '%s': %s\n", target->canonicalName().c_str(), target->path().c_str());
+            fprintf(stderr, "verbose: using sdk '%s': %s\n", target->canonicalName().value_or(target->bundleName()).c_str(), target->path().c_str());
         }
     }
 
@@ -325,10 +325,10 @@ static int Run(Filesystem *filesystem, process::Context const *processContext, p
         if (options.showSDKPath()) {
             printf("%s\n", target->path().c_str());
         } else if (options.showSDKVersion()) {
-            printf("%s\n", target->version().c_str());
+            printf("%s\n", target->version().value_or("").c_str());
         } else if (options.showSDKBuildVersion()) {
             if (auto product = target->product()) {
-                printf("%s\n", product->buildVersion().c_str());
+                printf("%s\n", product->buildVersion().value_or("").c_str());
             } else {
                 fprintf(stderr, "error: sdk has no build version\n");
                 return -1;
@@ -342,7 +342,7 @@ static int Run(Filesystem *filesystem, process::Context const *processContext, p
             }
         } else if (options.showSDKPlatformVersion()) {
             if (auto platform = target->platform()) {
-                printf("%s\n", platform->version().c_str());
+                printf("%s\n", platform->version().value_or("").c_str());
             } else {
                 fprintf(stderr, "error: sdk has no platform\n");
                 return -1;
@@ -385,7 +385,9 @@ static int Run(Filesystem *filesystem, process::Context const *processContext, p
         if (verbose) {
             fprintf(stderr, "verbose: using toolchain(s):");
             for (xcsdk::SDK::Toolchain::shared_ptr const &toolchain : toolchains) {
-                fprintf(stderr, " '%s'", toolchain->identifier().c_str());
+                if (toolchain->identifier()) {
+                    fprintf(stderr, " '%s'", toolchain->identifier()->c_str());
+                }
             }
             fprintf(stderr, "\n");
         }


### PR DESCRIPTION
 - Warn about missing keys when parsing; add currently missing keys.
 - Use optionals to avoid unsafely assuming parsed values always exist.
 - Update style to match other libraries.