### PR TITLE
Delay resolving executable paths until execution time.

### DIFF
--- a/Libraries/pbxbuild/Headers/pbxbuild/Tool/Context.h
+++ b/Libraries/pbxbuild/Headers/pbxbuild/Tool/Context.h
@@ -28,7 +28,6 @@ class Context {
 private:
     xcsdk::SDK::Target::shared_ptr _sdk;
     std::vector<xcsdk::SDK::Toolchain::shared_ptr> _toolchains;
-    std::vector<std::string>       _executablePaths;
     std::string                    _workingDirectory;
 
 private:
@@ -49,7 +48,6 @@ public:
     Context(
         xcsdk::SDK::Target::shared_ptr const &sdk,
         std::vector<xcsdk::SDK::Toolchain::shared_ptr> const &toolchains,
-        std::vector<std::string> const &executablePaths,
         std::string const &workingDirectory,
         SearchPaths const &searchPaths);
     ~Context();
@@ -59,8 +57,6 @@ public:
     { return _sdk; }
     std::vector<xcsdk::SDK::Toolchain::shared_ptr> const &toolchains() const
     { return _toolchains; }
-    std::vector<std::string> const &executablePaths() const
-    { return _executablePaths; }
     std::string const &workingDirectory() const
     { return _workingDirectory; }
 

--- a/Libraries/pbxbuild/Headers/pbxbuild/Tool/Invocation.h
+++ b/Libraries/pbxbuild/Headers/pbxbuild/Tool/Invocation.h
@@ -98,57 +98,50 @@ public:
      */
     class Executable {
     private:
-        std::string _path;
-        std::string _builtin;
+        ext::optional<std::string> _external;
+        ext::optional<std::string> _builtin;
 
-    public:
-        Executable(std::string const &path, std::string const &builtin);
+    private:
+        Executable(
+            ext::optional<std::string> const &external,
+            ext::optional<std::string> const &builtin);
 
     public:
         /*
-         * The path to the executable. If this executable is a bulitin tool, points
-         * to a standalone executable verison of that tool.
+         * An external executable, relative or absolute path.
          */
-        std::string const &path() const
-        { return _path; }
+        ext::optional<std::string> const &external() const
+        { return _external; }
 
         /*
-         * The name of the builtin tool this executable corresponds to.
+         * A builtin executable name.
          */
-        std::string const &builtin() const
+        ext::optional<std::string> const &builtin() const
         { return _builtin; }
 
     public:
         /*
-         * The user-facing name to show for the executable. For builtin tools, this
-         * uses the shorter name of the bulitin tool rather than the filesystem path.
-         */
-        std::string const &displayName() const;
-
-    public:
-        /*
-         * Creates an executable from an unknown string. The executable could
-         * be a builtin tool (starts with "builtin-"), an absolute path to a tool,
-         * or a relative path to search in the executable paths.
+         * Creates an executable with a known external path.
          */
         static Executable
-        Determine(std::string const &executable, std::vector<std::string> const &executablePaths);
-
-        /*
-         * Creates an executable with a known absolute path.
-         */
-        static Executable
-        Absolute(std::string const &path);
+        External(std::string const &path);
 
         /*
          * Creates an executable for a known built-in tool.
          */
         static Executable
         Builtin(std::string const &name);
+
+        /*
+         * Creates an executable from an unknown string. The executable could
+         * be a builtin tool (starts with "builtin-") or an external tool path.
+         */
+        static ext::optional<Executable>
+        Determine(std::string const &executable);
     };
 
 private:
-    Executable                                   _executable;
+    ext::optional<Executable>                    _executable;
     std::vector<std::string>                     _arguments;
     std::unordered_map<std::string, std::string> _environment;
     std::string                                  _workingDirectory;
@@ -178,7 +171,7 @@ public:
     ~Invocation();
 
 public:
-    Executable const &executable() const
+    ext::optional<Executable> const &executable() const
     { return _executable; }
     std::vector<std::string> const &arguments() const
     { return _arguments; }
@@ -188,7 +181,7 @@ public:
     { return _workingDirectory; }
 
 public:
-    Executable &executable()
+    ext::optional<Executable> &executable()
     { return _executable; }
     std::vector<std::string> &arguments()
     { return _arguments; }

--- a/Libraries/pbxbuild/Sources/Phase/PhaseInvocations.cpp
+++ b/Libraries/pbxbuild/Sources/Phase/PhaseInvocations.cpp
@@ -52,7 +52,6 @@ Create(Phase::Environment const &phaseEnvironment, pbxproj::PBX::Target::shared_
     Tool::Context toolContext = Tool::Context(
         targetEnvironment.sdk(),
         targetEnvironment.toolchains(),
-        targetEnvironment.executablePaths(),
         targetEnvironment.workingDirectory(),
         searchPaths);
 

--- a/Libraries/pbxbuild/Sources/Tool/AssetCatalogResolver.cpp
+++ b/Libraries/pbxbuild/Sources/Tool/AssetCatalogResolver.cpp
@@ -101,7 +101,7 @@ resolve(
      * Create the asset catalog invocation.
      */
     Tool::Invocation invocation;
-    invocation.executable() = Tool::Invocation::Executable::Determine(tokens.executable(), toolContext->executablePaths());
+    invocation.executable() = Tool::Invocation::Executable::Determine(tokens.executable());
     invocation.arguments() = arguments;
     invocation.environment() = environmentVariables;
     invocation.workingDirectory() = toolContext->workingDirectory();

--- a/Libraries/pbxbuild/Sources/Tool/ClangResolver.cpp
+++ b/Libraries/pbxbuild/Sources/Tool/ClangResolver.cpp
@@ -184,7 +184,7 @@ resolvePrecompiledHeader(
     }
 
     Tool::Invocation invocation;
-    invocation.executable() = Tool::Invocation::Executable::Determine(tokens.executable(), toolContext->executablePaths());
+    invocation.executable() = Tool::Invocation::Executable::Determine(tokens.executable());
     invocation.arguments() = arguments;
     invocation.environment() = options.environment();
     invocation.workingDirectory() = toolContext->workingDirectory();
@@ -282,7 +282,7 @@ resolveSource(
     }
 
     Tool::Invocation invocation;
-    invocation.executable() = Tool::Invocation::Executable::Determine(tokens.executable(), toolContext->executablePaths());
+    invocation.executable() = Tool::Invocation::Executable::Determine(tokens.executable());
     invocation.arguments() = arguments;
     invocation.environment() = options.environment();
     invocation.workingDirectory() = toolContext->workingDirectory();

--- a/Libraries/pbxbuild/Sources/Tool/Context.cpp
+++ b/Libraries/pbxbuild/Sources/Tool/Context.cpp
@@ -15,12 +15,10 @@ Tool::Context::
 Context(
     xcsdk::SDK::Target::shared_ptr const &sdk,
     std::vector<xcsdk::SDK::Toolchain::shared_ptr> const &toolchains,
-    std::vector<std::string> const &executablePaths,
     std::string const &workingDirectory,
     Tool::SearchPaths const &searchPaths) :
     _sdk             (sdk),
     _toolchains      (toolchains),
-    _executablePaths (executablePaths),
     _workingDirectory(workingDirectory),
     _searchPaths     (searchPaths)
 {

--- a/Libraries/pbxbuild/Sources/Tool/CopyResolver.cpp
+++ b/Libraries/pbxbuild/Sources/Tool/CopyResolver.cpp
@@ -42,8 +42,8 @@ ResolveInternal(
      * Add the copy-specific build settings.
      */
     pbxsetting::Level copyLevel = pbxsetting::Level({
-        pbxsetting::Setting::Create("PBXCP_STRIP_TOOL", Filesystem::GetDefaultUNSAFE()->findExecutable("strip", toolContext->executablePaths()).value_or(std::string())),
-        pbxsetting::Setting::Create("PBXCP_BITCODE_STRIP_TOOL", Filesystem::GetDefaultUNSAFE()->findExecutable("bitcode_strip", toolContext->executablePaths()).value_or(std::string())),
+        // TODO: pbxsetting::Setting::Create("PBXCP_STRIP_TOOL", toolchain->path() + "/usr/bin/strip"),
+        // TODO: pbxsetting::Setting::Create("PBXCP_BITCODE_STRIP_TOOL", toolchain->path() + "/usr/bin/bitcode_strip"),
         pbxsetting::Setting::Create("pbxcp_rule_name", logMessageTitle),
     });
 
@@ -91,7 +91,7 @@ ResolveInternal(
      * Create the copy invocation.
      */
     Tool::Invocation invocation;
-    invocation.executable() = Tool::Invocation::Executable::Determine(tokens.executable(), toolContext->executablePaths());
+    invocation.executable() = Tool::Invocation::Executable::Determine(tokens.executable());
     invocation.arguments() = tokens.arguments();
     invocation.environment() = options.environment();
     invocation.workingDirectory() = toolContext->workingDirectory();

--- a/Libraries/pbxbuild/Sources/Tool/DittoResolver.cpp
+++ b/Libraries/pbxbuild/Sources/Tool/DittoResolver.cpp
@@ -29,7 +29,7 @@ resolve(
     std::string logMessage = "Ditto " + targetPath + " " + sourcePath;
 
     Tool::Invocation invocation;
-    invocation.executable() = Tool::Invocation::Executable::Absolute("/usr/bin/ditto"); // TODO(grp): Ditto is not portable.
+    invocation.executable() = Tool::Invocation::Executable::External("/usr/bin/ditto"); // TODO(grp): Ditto is not portable.
     invocation.arguments() = { "-rsrc", sourcePath, targetPath };
     invocation.workingDirectory() = toolContext->workingDirectory();
     invocation.inputs() = { FSUtil::ResolveRelativePath(sourcePath, toolContext->workingDirectory()) };

--- a/Libraries/pbxbuild/Sources/Tool/InfoPlistResolver.cpp
+++ b/Libraries/pbxbuild/Sources/Tool/InfoPlistResolver.cpp
@@ -63,7 +63,7 @@ resolve(
     environmentVariables.insert(buildSettingValues.begin(), buildSettingValues.end());
 
     Tool::Invocation invocation;
-    invocation.executable() = Tool::Invocation::Executable::Determine(tokens.executable(), toolContext->executablePaths());
+    invocation.executable() = Tool::Invocation::Executable::Determine(tokens.executable());
     invocation.arguments() = tokens.arguments();
     invocation.environment() = environmentVariables;
     invocation.workingDirectory() = toolContext->workingDirectory();

--- a/Libraries/pbxbuild/Sources/Tool/InterfaceBuilderResolver.cpp
+++ b/Libraries/pbxbuild/Sources/Tool/InterfaceBuilderResolver.cpp
@@ -98,7 +98,7 @@ resolve(
      * Create the invocation.
      */
     Tool::Invocation invocation;
-    invocation.executable() = Tool::Invocation::Executable::Determine(tokens.executable(), toolContext->executablePaths());
+    invocation.executable() = Tool::Invocation::Executable::Determine(tokens.executable());
     invocation.arguments() = arguments;
     invocation.environment() = environmentVariables;
     invocation.workingDirectory() = toolContext->workingDirectory();

--- a/Libraries/pbxbuild/Sources/Tool/InterfaceBuilderStoryboardLinkerResolver.cpp
+++ b/Libraries/pbxbuild/Sources/Tool/InterfaceBuilderStoryboardLinkerResolver.cpp
@@ -80,7 +80,7 @@ resolve(
      * Create the invocation.
      */
     Tool::Invocation invocation;
-    invocation.executable() = Tool::Invocation::Executable::Determine(tokens.executable(), toolContext->executablePaths());
+    invocation.executable() = Tool::Invocation::Executable::Determine(tokens.executable());
     invocation.arguments() = arguments;
     invocation.environment() = environmentVariables;
     invocation.workingDirectory() = toolContext->workingDirectory();

--- a/Libraries/pbxbuild/Sources/Tool/LinkerResolver.cpp
+++ b/Libraries/pbxbuild/Sources/Tool/LinkerResolver.cpp
@@ -120,7 +120,7 @@ resolve(
     }
 
     Tool::Invocation invocation;
-    invocation.executable() = Tool::Invocation::Executable::Determine(tokens.executable(), toolContext->executablePaths());
+    invocation.executable() = Tool::Invocation::Executable::Determine(tokens.executable());
     invocation.arguments() = arguments;
     invocation.environment() = options.environment();
     invocation.workingDirectory() = toolContext->workingDirectory();

--- a/Libraries/pbxbuild/Sources/Tool/MakeDirectoryResolver.cpp
+++ b/Libraries/pbxbuild/Sources/Tool/MakeDirectoryResolver.cpp
@@ -29,7 +29,7 @@ resolve(
     std::string logMessage = "MkDir " + directory;
 
     Tool::Invocation invocation;
-    invocation.executable() = Tool::Invocation::Executable::Absolute("/bin/mkdir");
+    invocation.executable() = Tool::Invocation::Executable::External("/bin/mkdir");
     invocation.arguments() = { "-p", directory };
     invocation.workingDirectory() = toolContext->workingDirectory();
     invocation.outputs() = { FSUtil::ResolveRelativePath(directory, toolContext->workingDirectory()) };

--- a/Libraries/pbxbuild/Sources/Tool/ScriptResolver.cpp
+++ b/Libraries/pbxbuild/Sources/Tool/ScriptResolver.cpp
@@ -69,7 +69,7 @@ resolve(
     std::string fullWorkingDirectory = FSUtil::ResolveRelativePath(legacyTarget->buildWorkingDirectory(), toolContext->workingDirectory());
 
     Tool::Invocation invocation;
-    invocation.executable() = Tool::Invocation::Executable::Determine(legacyTarget->buildToolPath(), toolContext->executablePaths());
+    invocation.executable() = Tool::Invocation::Executable::Determine(legacyTarget->buildToolPath());
     invocation.arguments() = pbxsetting::Type::ParseList(script);
     invocation.environment() = environmentVariables;
     invocation.workingDirectory() = fullWorkingDirectory;
@@ -115,7 +115,7 @@ resolve(
     std::unordered_map<std::string, std::string> environmentVariables = scriptEnvironment.computeValues(pbxsetting::Condition::Empty());
 
     Tool::Invocation invocation;
-    invocation.executable() = Tool::Invocation::Executable::Absolute("/bin/sh");
+    invocation.executable() = Tool::Invocation::Executable::External("/bin/sh");
     invocation.arguments() = { "-c", Escape::Shell(scriptFilePath) };
     invocation.environment() = environmentVariables;
     invocation.workingDirectory() = toolContext->workingDirectory();
@@ -177,7 +177,7 @@ resolve(
     std::unordered_map<std::string, std::string> environmentVariables = ruleEnvironment.computeValues(pbxsetting::Condition::Empty());
 
     Tool::Invocation invocation;
-    invocation.executable() = Tool::Invocation::Executable::Absolute("/bin/sh");
+    invocation.executable() = Tool::Invocation::Executable::External("/bin/sh");
     invocation.arguments() = { "-c", buildRule->script() };
     invocation.environment() = environmentVariables;
     invocation.workingDirectory() = toolContext->workingDirectory();

--- a/Libraries/pbxbuild/Sources/Tool/SwiftResolver.cpp
+++ b/Libraries/pbxbuild/Sources/Tool/SwiftResolver.cpp
@@ -395,7 +395,7 @@ resolve(
      * Add the invocation.
      */
     Tool::Invocation invocation;
-    invocation.executable() = Tool::Invocation::Executable::Determine(tokens.executable(), toolContext->executablePaths());
+    invocation.executable() = Tool::Invocation::Executable::Determine(tokens.executable());
     invocation.arguments() = arguments;
     invocation.environment() = options.environment();
     invocation.workingDirectory() = toolContext->workingDirectory();

--- a/Libraries/pbxbuild/Sources/Tool/SwiftStandardLibraryResolver.cpp
+++ b/Libraries/pbxbuild/Sources/Tool/SwiftStandardLibraryResolver.cpp
@@ -45,7 +45,7 @@ resolve(
     Tool::Tokens::ToolExpansions tokens = Tool::Tokens::ExpandTool(toolEnvironment, options);
 
     Tool::Invocation invocation;
-    invocation.executable() = Tool::Invocation::Executable::Determine(tokens.executable(), toolContext->executablePaths());
+    invocation.executable() = Tool::Invocation::Executable::Determine(tokens.executable());
     invocation.arguments() = tokens.arguments();
     invocation.environment() = options.environment();
     invocation.workingDirectory() = toolContext->workingDirectory();

--- a/Libraries/pbxbuild/Sources/Tool/SymlinkResolver.cpp
+++ b/Libraries/pbxbuild/Sources/Tool/SymlinkResolver.cpp
@@ -31,7 +31,7 @@ resolve(
     std::string logMessage = "SymLink " + targetPath + " " + symlinkPath;
 
     Tool::Invocation invocation;
-    invocation.executable() = Tool::Invocation::Executable::Absolute("/bin/ln");
+    invocation.executable() = Tool::Invocation::Executable::External("/bin/ln");
     invocation.arguments() = { "-sfh", targetPath, symlinkPath };
     invocation.workingDirectory() = workingDirectory;
     invocation.phonyInputs() = { FSUtil::ResolveRelativePath(targetPath, workingDirectory) };

--- a/Libraries/pbxbuild/Sources/Tool/ToolResolver.cpp
+++ b/Libraries/pbxbuild/Sources/Tool/ToolResolver.cpp
@@ -51,7 +51,7 @@ resolve(
     }
 
     Tool::Invocation invocation;
-    invocation.executable() = Tool::Invocation::Executable::Determine(tokens.executable(), toolContext->executablePaths());
+    invocation.executable() = Tool::Invocation::Executable::Determine(tokens.executable());
     invocation.arguments() = tokens.arguments();
     invocation.environment() = options.environment();
     invocation.workingDirectory() = toolContext->workingDirectory();
@@ -76,7 +76,7 @@ resolve(
     std::string const &resolvedLogMessage = (!logMessage.empty() ? logMessage : tokens.logMessage());
 
     Tool::Invocation invocation;
-    invocation.executable() = Tool::Invocation::Executable::Determine(tokens.executable(), toolContext->executablePaths());
+    invocation.executable() = Tool::Invocation::Executable::Determine(tokens.executable());
     invocation.arguments() = tokens.arguments();
     invocation.environment() = options.environment();
     invocation.workingDirectory() = toolContext->workingDirectory();

--- a/Libraries/pbxbuild/Sources/Tool/TouchResolver.cpp
+++ b/Libraries/pbxbuild/Sources/Tool/TouchResolver.cpp
@@ -42,7 +42,7 @@ resolve(
     }
 
     Tool::Invocation invocation;
-    invocation.executable() = Tool::Invocation::Executable::Absolute("/usr/bin/touch");
+    invocation.executable() = Tool::Invocation::Executable::External("/usr/bin/touch");
     invocation.arguments() = { "-c", input };
     invocation.workingDirectory() = toolContext->workingDirectory();
     invocation.outputs() = { output };

--- a/Libraries/xcexecution/Headers/xcexecution/NinjaExecutor.h
+++ b/Libraries/xcexecution/Headers/xcexecution/NinjaExecutor.h
@@ -51,6 +51,7 @@ private:
         std::vector<pbxbuild::Tool::Invocation> const &invocations,
         std::unordered_set<std::string> *seenDirectories);
     bool buildTargetInvocations(
+        process::Context const *processContext,
         libutil::Filesystem *filesystem,
         std::string const &dependencyInfoToolPath,
         pbxproj::PBX::Target::shared_ptr const &target,
@@ -65,6 +66,7 @@ private:
     bool buildInvocation(
         ninja::Writer *writer,
         pbxbuild::Tool::Invocation const &invocation,
+        std::string const &executablePath,
         std::string const &dependencyInfoToolPath,
         std::string const &temporaryDirectory,
         std::string const &after);


### PR DESCRIPTION
Rather than looking at the filesystem to find an executable path at
configuration time, find the executable at execution time. This allows
different executors to handle searching for paths differently (for
example, using internal or external builtin tools), and avoids using
the filesystem during configuration.