### PR TITLE
Pass down PATH environment varaible to invocation

### DIFF
--- a/Libraries/pbxbuild/CMakeLists.txt
+++ b/Libraries/pbxbuild/CMakeLists.txt
@@ -26,6 +26,7 @@ add_library(pbxbuild SHARED
             Sources/Tool/ModuleMapInfo.cpp
             Sources/Tool/PrecompiledHeaderInfo.cpp
             Sources/Tool/SearchPaths.cpp
+            Sources/Tool/ResolverCommon.cpp
             Sources/Tool/CopyResolver.cpp
             Sources/Tool/DittoResolver.cpp
             Sources/Tool/SymlinkResolver.cpp

--- a/Libraries/pbxbuild/Headers/pbxbuild/Tool/ResolverCommon.h
+++ b/Libraries/pbxbuild/Headers/pbxbuild/Tool/ResolverCommon.h
@@ -1,0 +1,32 @@
+/**
+ Copyright (c) 2015-present, Facebook, Inc.
+ All rights reserved.
+
+ This source code is licensed under the BSD-style license found in the
+ LICENSE file in the root directory of this source tree. An additional grant
+ of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#ifndef __pbxbuild_Tool_ResolverCommon_h
+#define __pbxbuild_Tool_ResolverCommon_h
+
+#include <pbxbuild/Base.h>
+#include <pbxbuild/Tool/Environment.h>
+
+namespace pbxbuild {
+namespace Tool {
+
+class ResolverCommon {
+public:
+    static std::unordered_map<std::string, std::string> commonExtendedEnvironmentVariables(
+        pbxsetting::Environment const &environment,
+        const std::unordered_map<std::string, std::string> &environmentVariables);
+    static std::unordered_map<std::string, std::string> scriptExtendedEnvironmentVariables(
+        pbxsetting::Environment const &environment,
+        const std::unordered_map<std::string, std::string> &environmentVariables);
+};
+
+}
+}
+
+#endif

--- a/Libraries/pbxbuild/Sources/Tool/AssetCatalogResolver.cpp
+++ b/Libraries/pbxbuild/Sources/Tool/AssetCatalogResolver.cpp
@@ -11,6 +11,7 @@
 #include <pbxbuild/Tool/InterfaceBuilderCommon.h>
 #include <pbxbuild/Tool/Environment.h>
 #include <pbxbuild/Tool/OptionsResult.h>
+#include <pbxbuild/Tool/ResolverCommon.h>
 #include <pbxbuild/Tool/Tokens.h>
 #include <pbxbuild/Tool/Context.h>
 #include <pbxsetting/Type.h>
@@ -128,7 +129,7 @@ resolve(
     Tool::Invocation invocation;
     invocation.executable() = Tool::Invocation::Executable::Determine(tokens.executable());
     invocation.arguments() = arguments;
-    invocation.environment() = environmentVariables;
+    invocation.environment() = Tool::ResolverCommon::commonExtendedEnvironmentVariables(toolEnvironment.environment(), environmentVariables);
     invocation.workingDirectory() = toolContext->workingDirectory();
     invocation.inputs() = absoluteInputPaths;
     invocation.outputs() = outputs;

--- a/Libraries/pbxbuild/Sources/Tool/ClangResolver.cpp
+++ b/Libraries/pbxbuild/Sources/Tool/ClangResolver.cpp
@@ -16,6 +16,7 @@
 #include <pbxbuild/Tool/SearchPaths.h>
 #include <pbxbuild/Tool/Environment.h>
 #include <pbxbuild/Tool/OptionsResult.h>
+#include <pbxbuild/Tool/ResolverCommon.h>
 #include <pbxbuild/Tool/Tokens.h>
 #include <pbxsetting/Environment.h>
 #include <pbxsetting/Type.h>
@@ -183,7 +184,7 @@ resolvePrecompiledHeader(
     Tool::Invocation invocation;
     invocation.executable() = Tool::Invocation::Executable::Determine(tokens.executable());
     invocation.arguments() = arguments;
-    invocation.environment() = options.environment();
+    invocation.environment() = Tool::ResolverCommon::commonExtendedEnvironmentVariables(toolEnvironment.environment(), options.environment());
     invocation.workingDirectory() = toolContext->workingDirectory();
     invocation.inputs() = toolEnvironment.inputs(toolContext->workingDirectory());
     invocation.outputs() = toolEnvironment.outputs(toolContext->workingDirectory());

--- a/Libraries/pbxbuild/Sources/Tool/CopyResolver.cpp
+++ b/Libraries/pbxbuild/Sources/Tool/CopyResolver.cpp
@@ -10,6 +10,7 @@
 #include <pbxbuild/Tool/CopyResolver.h>
 #include <pbxbuild/Tool/Environment.h>
 #include <pbxbuild/Tool/OptionsResult.h>
+#include <pbxbuild/Tool/ResolverCommon.h>
 #include <pbxbuild/Tool/Tokens.h>
 #include <pbxbuild/Tool/Context.h>
 #include <libutil/Filesystem.h>
@@ -88,7 +89,7 @@ resolve(
     Tool::Invocation invocation;
     invocation.executable() = Tool::Invocation::Executable::Determine(tokens.executable());
     invocation.arguments() = tokens.arguments();
-    invocation.environment() = options.environment();
+    invocation.environment() = Tool::ResolverCommon::commonExtendedEnvironmentVariables(toolEnvironment.environment(), options.environment());
     invocation.workingDirectory() = toolContext->workingDirectory();
     invocation.inputs() = toolEnvironment.inputs(toolContext->workingDirectory());
     invocation.outputs() = toolEnvironment.outputs(toolContext->workingDirectory());

--- a/Libraries/pbxbuild/Sources/Tool/InfoPlistResolver.cpp
+++ b/Libraries/pbxbuild/Sources/Tool/InfoPlistResolver.cpp
@@ -10,6 +10,7 @@
 #include <pbxbuild/Tool/InfoPlistResolver.h>
 #include <pbxbuild/Tool/Environment.h>
 #include <pbxbuild/Tool/OptionsResult.h>
+#include <pbxbuild/Tool/ResolverCommon.h>
 #include <pbxbuild/Tool/Tokens.h>
 #include <pbxbuild/Tool/Context.h>
 #include <pbxsetting/Environment.h>
@@ -65,7 +66,7 @@ resolve(
     Tool::Invocation invocation;
     invocation.executable() = Tool::Invocation::Executable::Determine(tokens.executable());
     invocation.arguments() = tokens.arguments();
-    invocation.environment() = environmentVariables;
+    invocation.environment() = Tool::ResolverCommon::commonExtendedEnvironmentVariables(toolEnvironment.environment(), environmentVariables);
     invocation.workingDirectory() = toolContext->workingDirectory();
     invocation.inputs() = toolEnvironment.inputs(toolContext->workingDirectory());
     invocation.outputs() = toolEnvironment.outputs(toolContext->workingDirectory());

--- a/Libraries/pbxbuild/Sources/Tool/InterfaceBuilderResolver.cpp
+++ b/Libraries/pbxbuild/Sources/Tool/InterfaceBuilderResolver.cpp
@@ -11,6 +11,7 @@
 #include <pbxbuild/Tool/InterfaceBuilderCommon.h>
 #include <pbxbuild/Tool/Environment.h>
 #include <pbxbuild/Tool/OptionsResult.h>
+#include <pbxbuild/Tool/ResolverCommon.h>
 #include <pbxbuild/Tool/Tokens.h>
 #include <pbxbuild/Tool/Context.h>
 #include <pbxsetting/Environment.h>
@@ -100,7 +101,7 @@ resolve(
     Tool::Invocation invocation;
     invocation.executable() = Tool::Invocation::Executable::Determine(tokens.executable());
     invocation.arguments() = arguments;
-    invocation.environment() = environmentVariables;
+    invocation.environment() = Tool::ResolverCommon::commonExtendedEnvironmentVariables(toolEnvironment.environment(), environmentVariables);
     invocation.workingDirectory() = toolContext->workingDirectory();
     invocation.inputs() = toolEnvironment.inputs(toolContext->workingDirectory());
     invocation.outputs() = outputs;

--- a/Libraries/pbxbuild/Sources/Tool/InterfaceBuilderStoryboardLinkerResolver.cpp
+++ b/Libraries/pbxbuild/Sources/Tool/InterfaceBuilderStoryboardLinkerResolver.cpp
@@ -11,6 +11,7 @@
 #include <pbxbuild/Tool/InterfaceBuilderCommon.h>
 #include <pbxbuild/Tool/Environment.h>
 #include <pbxbuild/Tool/OptionsResult.h>
+#include <pbxbuild/Tool/ResolverCommon.h>
 #include <pbxbuild/Tool/Tokens.h>
 #include <pbxbuild/Tool/Context.h>
 #include <libutil/FSUtil.h>
@@ -82,7 +83,7 @@ resolve(
     Tool::Invocation invocation;
     invocation.executable() = Tool::Invocation::Executable::Determine(tokens.executable());
     invocation.arguments() = arguments;
-    invocation.environment() = environmentVariables;
+    invocation.environment() = Tool::ResolverCommon::commonExtendedEnvironmentVariables(toolEnvironment.environment(), environmentVariables);
     invocation.workingDirectory() = toolContext->workingDirectory();
     invocation.inputs() = toolEnvironment.inputs(toolContext->workingDirectory());
     invocation.outputs() = outputs;

--- a/Libraries/pbxbuild/Sources/Tool/LinkerResolver.cpp
+++ b/Libraries/pbxbuild/Sources/Tool/LinkerResolver.cpp
@@ -11,6 +11,7 @@
 #include <pbxbuild/Tool/Environment.h>
 #include <pbxbuild/Tool/Context.h>
 #include <pbxbuild/Tool/OptionsResult.h>
+#include <pbxbuild/Tool/ResolverCommon.h>
 #include <pbxbuild/Tool/Tokens.h>
 #include <libutil/FSUtil.h>
 
@@ -122,7 +123,7 @@ resolve(
     Tool::Invocation invocation;
     invocation.executable() = Tool::Invocation::Executable::Determine(tokens.executable());
     invocation.arguments() = arguments;
-    invocation.environment() = options.environment();
+    invocation.environment() = Tool::ResolverCommon::commonExtendedEnvironmentVariables(toolEnvironment.environment(), options.environment());
     invocation.workingDirectory() = toolContext->workingDirectory();
     invocation.inputs() = toolEnvironment.inputs(toolContext->workingDirectory());
     invocation.outputs() = toolEnvironment.outputs(toolContext->workingDirectory());

--- a/Libraries/pbxbuild/Sources/Tool/ResolverCommon.cpp
+++ b/Libraries/pbxbuild/Sources/Tool/ResolverCommon.cpp
@@ -1,0 +1,75 @@
+/**
+ Copyright (c) 2015-present, Facebook, Inc.
+ All rights reserved.
+
+ This source code is licensed under the BSD-style license found in the
+ LICENSE file in the root directory of this source tree. An additional grant
+ of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#include <pbxbuild/Tool/ResolverCommon.h>
+#include <sstream>
+
+namespace Tool = pbxbuild::Tool;
+
+static std::vector<std::string> sCommonPathEnvironmentExtensions = {
+    "$(PLATFORM_DEVELOPER_BIN_DIR)",
+    "$(DEVELOPER_BIN_DIR)",
+    "/usr/bin",
+    "/bin",
+    "/usr/sbin",
+    "/sbin",
+};
+
+static std::vector<std::string> sScriptPathEnvironmentExtensions = {
+    "$(DT_TOOLCHAIN_DIR)/usr/bin",
+    "$(DT_TOOLCHAIN_DIR)/usr/libexec",
+    "$(PLATFORM_DIR)/Developer/usr/bin",
+    "$(PLATFORM_DIR)/usr/local/bin",
+    "$(PLATFORM_DIR)/usr/bin",
+    "$(PLATFORM_DIR)/usr/local/bin",
+    "$(DEVELOPER_DIR)/usr/bin",
+    "$(DEVELOPER_DIR)/usr/local/bin",
+    "$(DEVELOPER_DIR)/Tools",
+    "/usr/bin",
+    "/bin",
+    "/usr/sbin",
+    "/sbin",
+};
+
+static std::string
+_PathEnvironmentVariable(
+    pbxsetting::Environment const &environment,
+    std::vector<std::string> &extensions)
+{
+    std::string pathEnvironmentVariable;
+    for (auto it = extensions.begin(); it != extensions.end(); it++) {
+        if (pathEnvironmentVariable.length()) {
+            pathEnvironmentVariable += ":";
+        }
+        pathEnvironmentVariable += environment.expand(pbxsetting::Value::Parse(*it));
+    }
+    return pathEnvironmentVariable;
+}
+
+std::unordered_map<std::string, std::string> Tool::ResolverCommon::
+commonExtendedEnvironmentVariables(
+    pbxsetting::Environment const &environment,
+    const std::unordered_map<std::string, std::string> &environmentVariables)
+{
+    auto pathEnvironmentVariable = _PathEnvironmentVariable(environment, sCommonPathEnvironmentExtensions);
+    auto pathExtendedEnvironmentVariables = environmentVariables;
+    pathExtendedEnvironmentVariables["PATH"] += pathEnvironmentVariable;
+    return pathExtendedEnvironmentVariables;
+}
+
+std::unordered_map<std::string, std::string> Tool::ResolverCommon::
+scriptExtendedEnvironmentVariables(
+    pbxsetting::Environment const &environment,
+    const std::unordered_map<std::string, std::string> &environmentVariables)
+{
+    auto pathEnvironmentVariable = _PathEnvironmentVariable(environment, sScriptPathEnvironmentExtensions);
+    auto pathExtendedEnvironmentVariables = environmentVariables;
+    pathExtendedEnvironmentVariables["PATH"] += pathEnvironmentVariable;
+    return pathExtendedEnvironmentVariables;
+}

--- a/Libraries/pbxbuild/Sources/Tool/ScriptResolver.cpp
+++ b/Libraries/pbxbuild/Sources/Tool/ScriptResolver.cpp
@@ -10,6 +10,7 @@
 #include <pbxbuild/Tool/ScriptResolver.h>
 #include <pbxbuild/Tool/Context.h>
 #include <pbxsetting/Environment.h>
+#include <pbxbuild/Tool/ResolverCommon.h>
 #include <pbxsetting/Level.h>
 #include <pbxsetting/Setting.h>
 #include <pbxsetting/Type.h>
@@ -181,7 +182,7 @@ resolve(
     Tool::Invocation invocation;
     invocation.executable() = Tool::Invocation::Executable::External("/bin/sh");
     invocation.arguments() = { "-c", buildRule->script() };
-    invocation.environment() = environmentVariables;
+    invocation.environment() = Tool::ResolverCommon::scriptExtendedEnvironmentVariables(ruleEnvironment, environmentVariables);
     invocation.workingDirectory() = toolContext->workingDirectory();
     invocation.inputs() = { inputAbsolutePath };
     invocation.outputs() = outputFiles;

--- a/Libraries/pbxbuild/Sources/Tool/SwiftResolver.cpp
+++ b/Libraries/pbxbuild/Sources/Tool/SwiftResolver.cpp
@@ -11,6 +11,7 @@
 #include <pbxbuild/Tool/CompilerCommon.h>
 #include <pbxbuild/Tool/Environment.h>
 #include <pbxbuild/Tool/OptionsResult.h>
+#include <pbxbuild/Tool/ResolverCommon.h>
 #include <pbxbuild/Tool/Tokens.h>
 #include <pbxbuild/Tool/Context.h>
 #include <pbxsetting/Environment.h>
@@ -398,7 +399,7 @@ resolve(
     Tool::Invocation invocation;
     invocation.executable() = Tool::Invocation::Executable::Determine(tokens.executable());
     invocation.arguments() = arguments;
-    invocation.environment() = options.environment();
+    invocation.environment() = Tool::ResolverCommon::commonExtendedEnvironmentVariables(toolEnvironment.environment(), options.environment());
     invocation.workingDirectory() = toolContext->workingDirectory();
     invocation.inputs() = toolEnvironment.inputs(toolContext->workingDirectory());
     invocation.outputs() = outputs;

--- a/Libraries/pbxbuild/Sources/Tool/SwiftStandardLibraryResolver.cpp
+++ b/Libraries/pbxbuild/Sources/Tool/SwiftStandardLibraryResolver.cpp
@@ -10,6 +10,7 @@
 #include <pbxbuild/Tool/SwiftStandardLibraryResolver.h>
 #include <pbxbuild/Tool/Environment.h>
 #include <pbxbuild/Tool/OptionsResult.h>
+#include <pbxbuild/Tool/ResolverCommon.h>
 #include <pbxbuild/Tool/Tokens.h>
 #include <pbxbuild/Tool/Context.h>
 #include <pbxsetting/Environment.h>
@@ -47,7 +48,7 @@ resolve(
     Tool::Invocation invocation;
     invocation.executable() = Tool::Invocation::Executable::Determine(tokens.executable());
     invocation.arguments() = tokens.arguments();
-    invocation.environment() = options.environment();
+    invocation.environment() = Tool::ResolverCommon::commonExtendedEnvironmentVariables(toolEnvironment.environment(), options.environment());
     invocation.workingDirectory() = toolContext->workingDirectory();
     invocation.inputs() = toolEnvironment.inputs(toolContext->workingDirectory());
     invocation.outputs() = { }; // TODO(grp): Outputs are not known at build time.

--- a/Libraries/pbxbuild/Sources/Tool/ToolResolver.cpp
+++ b/Libraries/pbxbuild/Sources/Tool/ToolResolver.cpp
@@ -11,6 +11,7 @@
 #include <pbxbuild/Tool/Environment.h>
 #include <pbxbuild/Tool/Tokens.h>
 #include <pbxbuild/Tool/OptionsResult.h>
+#include <pbxbuild/Tool/ResolverCommon.h>
 #include <pbxbuild/Tool/Context.h>
 #include <libutil/FSUtil.h>
 
@@ -78,7 +79,7 @@ resolve(
     Tool::Invocation invocation;
     invocation.executable() = Tool::Invocation::Executable::Determine(tokens.executable());
     invocation.arguments() = tokens.arguments();
-    invocation.environment() = options.environment();
+    invocation.environment() = Tool::ResolverCommon::commonExtendedEnvironmentVariables(toolEnvironment.environment(), options.environment());
     invocation.workingDirectory() = toolContext->workingDirectory();
     invocation.inputs() = toolEnvironment.inputs(toolContext->workingDirectory());
     invocation.outputs() = toolEnvironment.outputs(toolContext->workingDirectory());


### PR DESCRIPTION
Tools invoked will sometimes expect PATH environment variable to be explicitly set
and contain the path the xcbuild searched for invocation.
