### PR TITLE
Improve JSON parsing to handle more edge cases.

### DIFF
--- a/Libraries/plist/Tests/Format/test_JSON.cpp
+++ b/Libraries/plist/Tests/Format/test_JSON.cpp
@@ -98,3 +98,43 @@ TEST(JSON, Empty)
     ASSERT_EQ(deserialize.first, nullptr);
 }
 
+TEST(JSON, SingleQuotes)
+{
+    /* Single quotes are not allowed in JSON. */
+    auto contents = Contents("{ 'one': 1 }");
+    auto deserialize = JSON::Deserialize(contents, JSON::Create());
+    EXPECT_EQ(deserialize.first, nullptr);
+}
+
+TEST(JSON, Number)
+{
+    /* Numbers can be zero. */
+    auto contents1 = Contents("{ \"key\" : 0 }");
+    auto deserialize1 = JSON::Deserialize(contents1, JSON::Create());
+    EXPECT_NE(deserialize1.first, nullptr);
+
+    /* Numbers cannot start with zero. */
+    auto contents2 = Contents("{ \"key\" : 01 }");
+    auto deserialize2 = JSON::Deserialize(contents2, JSON::Create());
+    EXPECT_EQ(deserialize2.first, nullptr);
+
+    /* Numbers cannot have a positive sign. */
+    auto contents3 = Contents("{ \"key\" : +1 }");
+    auto deserialize3 = JSON::Deserialize(contents3, JSON::Create());
+    EXPECT_EQ(deserialize3.first, nullptr);
+
+    /* Numbers can have a negative sign. */
+    auto contents4 = Contents("{ \"key\" : -1 }");
+    auto deserialize4 = JSON::Deserialize(contents4, JSON::Create());
+    EXPECT_NE(deserialize4.first, nullptr);
+
+    /* Decimals must have a value. */
+    auto contents5 = Contents("{ \"key\" : 1. }");
+    auto deserialize5 = JSON::Deserialize(contents5, JSON::Create());
+    EXPECT_EQ(deserialize5.first, nullptr);
+
+    /* Exponents must have a value. */
+    auto contents6 = Contents("{ \"key\" : 1e+ }");
+    auto deserialize6 = JSON::Deserialize(contents6, JSON::Create());
+    EXPECT_EQ(deserialize6.first, nullptr);
+}


### PR DESCRIPTION
Using a JSON parser test suite, refine number and key parsing to match
the JSON specification. Remaining issues are related to Unicode support,
escape sequences, and trailing commas.

The last of those is intentionally non-conforming for compatibility.
