### PR TITLE
Partially update asset catalog compiler specification and resolver.

### DIFF
--- a/Libraries/acdriver/Headers/acdriver/Options.h
+++ b/Libraries/acdriver/Headers/acdriver/Options.h
@@ -71,6 +71,7 @@ private:
     ext::optional<std::string> _targetName;
     ext::optional<std::string> _filterForDeviceModel;
     ext::optional<std::string> _filterForDeviceOsVersion;
+    ext::optional<std::string> _assetPackOutputSpecifications;
 
 public:
     Options();
@@ -148,6 +149,8 @@ public:
     { return _filterForDeviceModel; }
     ext::optional<std::string> const &filterForDeviceOsVersion() const
     { return _filterForDeviceOsVersion; }
+    ext::optional<std::string> const &assetPackOutputSpecifications() const
+    { return _assetPackOutputSpecifications; }
 
 private:
     friend class libutil::Options;

--- a/Libraries/acdriver/Sources/CompileAction.cpp
+++ b/Libraries/acdriver/Sources/CompileAction.cpp
@@ -206,7 +206,7 @@ WarnUnsupportedOptions(Options const &options, Result *result)
     }
 
     if (options.stickerPackIdentifierPrefix() || options.stickerPackStringsFile()) {
-        /* Strings file format: `sticker-pack:language-identifier:path`. */
+        /* Strings file format: `sticker-pack-name:language-identifier:path`. */
         result->normal(Result::Severity::Warning, "sticker pack not supported");
     }
 

--- a/Libraries/acdriver/Sources/Options.cpp
+++ b/Libraries/acdriver/Sources/Options.cpp
@@ -82,6 +82,8 @@ parseArgument(std::vector<std::string> const &args, std::vector<std::string>::co
         return libutil::Options::Next<std::string>(&_filterForDeviceModel, args, it);
     } else if (arg == "--filter-for-device-os-version") {
         return libutil::Options::Next<std::string>(&_filterForDeviceOsVersion, args, it);
+    } else if (arg == "--asset-pack-output-specifications") {
+        return libutil::Options::Next<std::string>(&_assetPackOutputSpecifications, args, it);
     } else if (!arg.empty() && arg[0] != '-') {
         return libutil::Options::AppendCurrent<std::string>(&_inputs, arg);
     } else {

--- a/Libraries/pbxbuild/Sources/Phase/Context.cpp
+++ b/Libraries/pbxbuild/Sources/Phase/Context.cpp
@@ -217,6 +217,9 @@ Group(std::vector<Phase::File> const &files)
             /* Keyed on both the file name and tool. */
             std::string base = FSUtil::GetBaseNameWithoutExtension(file.path());
             groupedCommonBase[compiler->identifier()][base].push_back(file);
+        } else if (grouping == "actool") {
+            groupedTool[compiler->identifier()].push_back(file);
+            // TODO: group strings files with a base name matching a sticker pack in an asset catalog. how?
         } else if (grouping == "ib-base-region-and-strings") {
             /* Only "Base" region files. See below for finding additional grouped files. */
             if (file.localization() == "Base") {

--- a/Specifications/Compiler/com.apple.compilers.assetcatalog.xcspec
+++ b/Specifications/Compiler/com.apple.compilers.assetcatalog.xcspec
@@ -12,15 +12,19 @@
     Identifier = com.apple.compilers.assetcatalog;
     Name = "Asset Catalog Compiler";
 
-    CommandLine = "actool [options] [special-args] [inputs] --compile $(ProductResourcesDir)";
-    RuleName = "CompileAssetCatalog $(ProductResourcesDir) [inputs]";
+    CommandLine = "actool --product-type $(PRODUCT_TYPE) [options] [special-args] --compile $(ProductResourcesDir) $(ASSETCATALOG_COMPILER_INPUTS)";
+    RuleName = "CompileAssetCatalog $(ProductResourcesDir) $(ASSETCATALOG_COMPILER_INPUTS)";
 
-    InputFileGroupings = ( "tool" );
+    InputFileGroupings = ( "actool" );
     InputFileTypes = (
         "folder.assetcatalog",
         "folder.imagecatalog",
+        "folder.stickers",
     );
     Outputs = ( ); /* Dynamic based on inputs. */
+    AdditionalDirectoriesToCreate = (
+        "$(ProductResourcesDir)",
+    );
     DeeplyStatInputDirectories = YES;
     DependencyInfoFile = "$(ASSETCATALOG_COMPILER_DEPENDENCY_INFO_FILE)";
     GeneratedInfoPlistContentFilePath = "$(ASSETCATALOG_COMPILER_INFOPLIST_CONTENT_FILE)";
@@ -72,7 +76,6 @@
         {
             Name = "RESOURCES_TARGETED_DEVICE_FAMILY";
             Type = StringList;
-            DefaultValue = "$(TARGETED_DEVICE_FAMILY)";
             CommandLineFlag = "--target-device";
         },
 
@@ -89,6 +92,21 @@
             Type = String;
             DefaultValue = "";
             CommandLineFlag = "--launch-image";
+        },
+
+
+        /* Stickers */
+        {
+            Name = "ASSETCATALOG_COMPILER_STICKER_PACK_STRINGS";
+            Type = PathList;
+            DefaultValue = "";
+            CommandLineFlag = "--sticker-pack-strings-file";
+        },
+        {
+            Name = "ASSETCATALOG_COMPILER_STICKER_PACK_IDENTIFIER_PREFIX";
+            Type = String;
+            DefaultValue = "$(PRODUCT_BUNDLE_IDENTIFIER).sticker-pack.";
+            CommandLineFlag = "--sticker-pack-identifier-prefix";
         },
 
 


### PR DESCRIPTION
Asset catalog compilation now uses a custom variable to pass inputs
to the specification, and a custom grouping method to group inputs.

Does not pass sticker pack translations to asset catalog compiler,
as this seems to require parsing the asset catalog just to determine
which strings files should be used. Left as a future task.