### PR TITLE
fix builtin pbxcp

### DIFF
--- a/Specifications/Tool/com.apple.compilers.pbxcp.xcspec
+++ b/Specifications/Tool/com.apple.compilers.pbxcp.xcspec
@@ -11,7 +11,7 @@
     Type = Tool;
     Identifier = com.apple.compilers.pbxcp;
     Name = "Copy Utility";
-    CommandLine = "builtin-copy [options] [inputs] [output]";
+    ExecPath = "builtin-copy";
     RuleName = "$(pbxcp_rule_name:quote) $(OutputFile:quote) $(InputFile:quote)";
     DeeplyStatInputDirectories = YES;
 


### PR DESCRIPTION
pbx cp command should specify output dir, not the output file path.