### PR TITLE
Prevent infinite loop in createDirectory.

### DIFF
--- a/Libraries/libutil/Sources/DefaultFilesystem.cpp
+++ b/Libraries/libutil/Sources/DefaultFilesystem.cpp
@@ -453,7 +453,7 @@ createDirectory(std::string const &path, bool recursive)
         std::stack<std::string> create;
 
         /* Build up list of directories to create. */
-        while (this->type(path) != Type::Directory) {
+        while (this->type(current) != Type::Directory) {
             create.push(current);
             current = FSUtil::GetDirectoryName(current);
         }


### PR DESCRIPTION
createDirectory entered an infinite loop breaking xcbuild.

I was looking into adding tests for this but I can't figure out how to do that safely. There should be some way to create a container in CTest so we can write the tests just like those for MemoryFilesystem.