### PR TITLE
Make fileNameDisambiguator optional in File::ResolveBuildFiles

### DIFF
--- a/Libraries/pbxbuild/Sources/Phase/File.cpp
+++ b/Libraries/pbxbuild/Sources/Phase/File.cpp
@@ -38,7 +38,7 @@ ResolveBuildFiles(Filesystem const *filesystem, Phase::Environment const &phaseE
             continue;
         }
 
-        std::string fileNameDisambiguator;
+        ext::optional<std::string> fileNameDisambiguator;
         auto it = targetEnvironment.buildFileDisambiguation().find(buildFile);
         if (it != targetEnvironment.buildFileDisambiguation().end()) {
             fileNameDisambiguator = it->second;


### PR DESCRIPTION
Previously it was by default always set, but to an empty string.

This avoids having an empty outputBaseName later in ClangResolver,
which caused the output object files be named ".o" for all input
source files.