### PR TITLE
deployment target version env name fix

### DIFF
--- a/Libraries/xcsdk/Sources/SDK/Platform.cpp
+++ b/Libraries/xcsdk/Sources/SDK/Platform.cpp
@@ -126,7 +126,7 @@ settings() const
     settings.push_back(pbxsetting::Setting::Create("DEPLOYMENT_TARGET_SETTING_NAME", settingName + "_DEPLOYMENT_TARGET"));
     settings.push_back(pbxsetting::Setting::Create("DEPLOYMENT_TARGET_CLANG_FLAG_NAME", "m" + flagName + "-version-min"));
     settings.push_back(pbxsetting::Setting::Create("DEPLOYMENT_TARGET_CLANG_FLAG_PREFIX", "-m" + flagName + "-version-min="));
-    settings.push_back(pbxsetting::Setting::Create("DEPLOYMENT_TARGET_CLANG_FLAG_ENV", envName + "_DEPLOYMENT_TARGET"));
+    settings.push_back(pbxsetting::Setting::Create("DEPLOYMENT_TARGET_CLANG_ENV_NAME", envName + "_DEPLOYMENT_TARGET"));
     settings.push_back(pbxsetting::Setting::Create("SWIFT_PLATFORM_TARGET_PREFIX", swiftName));
 
     settings.push_back(pbxsetting::Setting::Parse("EFFECTIVE_PLATFORM_NAME", (_name == "macosx" ? "" : "-$(PLATFORM_NAME)")));


### PR DESCRIPTION
I believe DEPLOYMENT_TARGET_CLANG_FLAG_ENV should actually be DEPLOYMENT_TARGET_CLANG_ENV_NAME?