### PR TITLE
Fix recursive createDirectory for relative paths

### DIFF
--- a/Libraries/libutil/Sources/DefaultFilesystem.cpp
+++ b/Libraries/libutil/Sources/DefaultFilesystem.cpp
@@ -453,7 +453,7 @@ createDirectory(std::string const &path, bool recursive)
         std::stack<std::string> create;
 
         /* Build up list of directories to create. */
-        while (this->type(current) != Type::Directory) {
+        while (this->type(current) != Type::Directory && current != "") {
             create.push(current);
             current = FSUtil::GetDirectoryName(current);
         }


### PR DESCRIPTION
A path like "foo/bar/baz" will end up looking for a directory
named "" unless any of the earlier directories already exist.