### PR TITLE
ignore non-directory path in dependency-info-tool

### DIFF
--- a/Libraries/dependency/Tools/dependency-info-tool.cpp
+++ b/Libraries/dependency/Tools/dependency-info-tool.cpp
@@ -162,6 +162,11 @@ LoadDependencyInfo(Filesystem const *filesystem, std::string const &path, depend
         dependencyInfo->push_back(binaryInfo->dependencyInfo());
         return true;
     } else if (format == dependency::DependencyInfoFormat::Directory) {
+        if (filesystem->type(path) != Filesystem::Type::Directory) {
+            fprintf(stderr, "warning: ignoring non-directory %s\n", path.c_str());
+            return true;
+        }
+
         auto directoryInfo = dependency::DirectoryDependencyInfo::Deserialize(filesystem, path);
         if (!directoryInfo) {
             fprintf(stderr, "error: invalid directory\n");


### PR DESCRIPTION
sometimes we'd want to depend on a single file, not entire directory
subtree.
rename DirectoryDependnecyInfo to PathDependencyInfo and make it
handle both cases.