### PR TITLE
Pass correct environment to tools.

### DIFF
--- a/Libraries/pbxbuild/Headers/pbxbuild/Build/Environment.h
+++ b/Libraries/pbxbuild/Headers/pbxbuild/Build/Environment.h
@@ -31,12 +31,14 @@ private:
     pbxspec::Manager::shared_ptr         _specManager;
     std::shared_ptr<xcsdk::SDK::Manager> _sdkManager;
     pbxsetting::Environment              _baseEnvironment;
+    std::vector<std::string>             _baseExecutablePaths;
 
 public:
     Environment(
         pbxspec::Manager::shared_ptr const &specManager,
         std::shared_ptr<xcsdk::SDK::Manager> const &sdkManager,
-        pbxsetting::Environment const &baseEnvironment);
+        pbxsetting::Environment const &baseEnvironment,
+        std::vector<std::string> const &baseExecutablePaths);
 
 public:
     /*
@@ -57,6 +59,12 @@ public:
      */
     pbxsetting::Environment const &baseEnvironment() const
     { return _baseEnvironment; }
+
+    /*
+     * The base executable paths from the system.
+     */
+    std::vector<std::string> const &baseExecutablePaths() const
+    { return _baseExecutablePaths; }
 
 public:
     /*

--- a/Libraries/pbxbuild/Sources/Build/Environment.cpp
+++ b/Libraries/pbxbuild/Sources/Build/Environment.cpp
@@ -12,16 +12,22 @@
 #include <xcsdk/Environment.h>
 #include <pbxsetting/DefaultSettings.h>
 #include <pbxsetting/Environment.h>
+#include <process/Context.h>
 #include <libutil/Filesystem.h>
 
 namespace Build = pbxbuild::Build;
 using libutil::Filesystem;
 
 Build::Environment::
-Environment(pbxspec::Manager::shared_ptr const &specManager, std::shared_ptr<xcsdk::SDK::Manager> const &sdkManager, pbxsetting::Environment const &baseEnvironment) :
+Environment(
+    pbxspec::Manager::shared_ptr const &specManager,
+    std::shared_ptr<xcsdk::SDK::Manager> const &sdkManager,
+    pbxsetting::Environment const &baseEnvironment,
+    std::vector<std::string> const &baseExecutablePaths) :
     _specManager(specManager),
     _sdkManager(sdkManager),
-    _baseEnvironment(baseEnvironment)
+    _baseEnvironment(baseEnvironment),
+    _baseExecutablePaths(baseExecutablePaths)
 {
 }
 
@@ -91,5 +97,5 @@ Default(process::Context const *processContext, Filesystem const *filesystem)
         baseEnvironment.insertBack(level, false);
     }
 
-    return Build::Environment(specManager, sdkManager, baseEnvironment);
+    return Build::Environment(specManager, sdkManager, baseEnvironment, processContext->executableSearchPaths());
 }

--- a/Libraries/pbxbuild/Sources/Target/Environment.cpp
+++ b/Libraries/pbxbuild/Sources/Target/Environment.cpp
@@ -264,6 +264,22 @@ ArchitecturesVariantsLevel(std::vector<std::string> const &architectures, std::v
     return pbxsetting::Level(settings);
 }
 
+static pbxsetting::Level
+ExecutablePathsLevel(std::vector<std::string> const &executablePaths)
+{
+    std::string path;
+    for (std::string const &executablePath : executablePaths) {
+        path += executablePath;
+        if (&executablePath != &executablePaths.back()) {
+            path += ":";
+        }
+    }
+
+    return pbxsetting::Level({
+        pbxsetting::Setting::Create("PATH", path),
+    });
+}
+
 ext::optional<Target::Environment> Target::Environment::
 Create(Build::Environment const &buildEnvironment, Build::Context const &buildContext, pbxproj::PBX::Target::shared_ptr const &target)
 {
@@ -451,6 +467,8 @@ Create(Build::Environment const &buildEnvironment, Build::Context const &buildCo
     /* Tool search directories. Use the toolchains just discovered. */
     std::shared_ptr<xcsdk::SDK::Manager> const &sdkManager = buildEnvironment.sdkManager();
     std::vector<std::string> executablePaths = sdkManager->executablePaths(sdk->platform(), sdk, toolchains);
+    executablePaths.insert(executablePaths.end(), buildEnvironment.baseExecutablePaths().begin(), buildEnvironment.baseExecutablePaths().end());
+    environment.insertFront(ExecutablePathsLevel(executablePaths), false);
 
     auto buildRules = Target::BuildRules::Create(buildEnvironment.specManager(), specDomains, target);
     auto buildFileDisambiguation = BuildFileDisambiguation(target);

--- a/Libraries/pbxbuild/Sources/Tool/AssetCatalogResolver.cpp
+++ b/Libraries/pbxbuild/Sources/Tool/AssetCatalogResolver.cpp
@@ -92,14 +92,6 @@ resolve(
     arguments.erase(std::remove(arguments.begin(), arguments.end(), "--optimization"), arguments.end());
     arguments.erase(std::remove(arguments.begin(), arguments.end(), ""), arguments.end());
 
-    // TODO(grp): These should be handled generically for all tools.
-    std::unordered_map<std::string, std::string> environmentVariables = options.environment();
-    if (_tool->environmentVariables()) {
-        for (auto const &variable : *_tool->environmentVariables()) {
-            environmentVariables.insert({ variable.first, environment.expand(variable.second) });
-        }
-    }
-
     // TODO(grp): This should be handled generically for all tools.
     if (_tool->generatedInfoPlistContentFilePath()) {
         std::string infoPlistContent = environment.expand(*_tool->generatedInfoPlistContentFilePath());
@@ -128,7 +120,7 @@ resolve(
     Tool::Invocation invocation;
     invocation.executable() = Tool::Invocation::Executable::Determine(tokens.executable());
     invocation.arguments() = arguments;
-    invocation.environment() = environmentVariables;
+    invocation.environment() = options.environment();
     invocation.workingDirectory() = toolContext->workingDirectory();
     invocation.inputs() = absoluteInputPaths;
     invocation.outputs() = outputs;

--- a/Libraries/pbxbuild/Sources/Tool/InterfaceBuilderResolver.cpp
+++ b/Libraries/pbxbuild/Sources/Tool/InterfaceBuilderResolver.cpp
@@ -79,14 +79,6 @@ resolve(
         outputs = { outputs.front() };
     }
 
-    // TODO(grp): These should be handled generically for all tools.
-    std::unordered_map<std::string, std::string> environmentVariables = options.environment();
-    if (_tool->environmentVariables()) {
-        for (auto const &variable : *_tool->environmentVariables()) {
-            environmentVariables.insert({ variable.first, environment.expand(variable.second) });
-        }
-    }
-
     // TODO(grp): This should be handled generically for all tools.
     if (_tool->generatedInfoPlistContentFilePath()) {
         std::string infoPlistContent = environment.expand(*_tool->generatedInfoPlistContentFilePath());
@@ -100,7 +92,7 @@ resolve(
     Tool::Invocation invocation;
     invocation.executable() = Tool::Invocation::Executable::Determine(tokens.executable());
     invocation.arguments() = arguments;
-    invocation.environment() = environmentVariables;
+    invocation.environment() = options.environment();
     invocation.workingDirectory() = toolContext->workingDirectory();
     invocation.inputs() = toolEnvironment.inputs(toolContext->workingDirectory());
     invocation.outputs() = outputs;

--- a/Libraries/pbxbuild/Sources/Tool/InterfaceBuilderStoryboardLinkerResolver.cpp
+++ b/Libraries/pbxbuild/Sources/Tool/InterfaceBuilderStoryboardLinkerResolver.cpp
@@ -68,21 +68,13 @@ resolve(
     std::vector<std::string> deploymentTargetArguments = InterfaceBuilderCommon::DeploymentTargetArguments(environment);
     arguments.insert(arguments.end(), deploymentTargetArguments.begin(), deploymentTargetArguments.end());
 
-    // TODO(grp): These should be handled generically for all tools.
-    std::unordered_map<std::string, std::string> environmentVariables = options.environment();
-    if (_tool->environmentVariables()) {
-        for (auto const &variable : *_tool->environmentVariables()) {
-            environmentVariables.insert({ variable.first, environment.expand(variable.second) });
-        }
-    }
-
     /*
      * Create the invocation.
      */
     Tool::Invocation invocation;
     invocation.executable() = Tool::Invocation::Executable::Determine(tokens.executable());
     invocation.arguments() = arguments;
-    invocation.environment() = environmentVariables;
+    invocation.environment() = options.environment();
     invocation.workingDirectory() = toolContext->workingDirectory();
     invocation.inputs() = toolEnvironment.inputs(toolContext->workingDirectory());
     invocation.outputs() = outputs;

--- a/Libraries/xcexecution/Sources/NinjaExecutor.cpp
+++ b/Libraries/xcexecution/Sources/NinjaExecutor.cpp
@@ -513,7 +513,7 @@ buildAction(
      * rules at the Ninja level. Instead, add a single rule that just passes through from
      * the build command that calls it.
      */
-    writer.rule(NinjaRuleName(), ninja::Value::Expression("cd $dir && env -i $env $exec && $depexec"));
+    writer.rule(NinjaRuleName(), ninja::Value::Expression("cd $dir && env $env $exec && $depexec"));
 
     /*
      * Go over each target and write out Ninja targets for the start and end of each.
@@ -806,9 +806,9 @@ buildInvocation(
     }
 
     /*
-     * Build the invocation environment. To set the environment, we use standard shell syntax.
-     * Use `env` to avoid Bash-specific limitations on environment variables. Specifically, some
-     * versions of Bash don't allow setting "UID". Pass -i to clear out the environment.
+     * Build the invocation environment. To set the environment, we use standard shell tools:
+     * `env` to avoid Bash-specific limitations on environment variables (some versions of Bash
+     * don't allow setting "UID"). Intentionally add to, not replace, the process environment.
      */
     std::string environment;
     for (auto it = invocation.environment().begin(); it != invocation.environment().end(); ++it) {

--- a/Libraries/xcexecution/Sources/SimpleExecutor.cpp
+++ b/Libraries/xcexecution/Sources/SimpleExecutor.cpp
@@ -277,11 +277,15 @@ performInvocations(
                 if (path) {
                     xcformatter::Formatter::Print(_formatter->beginInvocation(invocation, *path, createProductStructure));
 
+                    /* Create the execution environment from the process and invocation environments, preferring the invocation. */
+                    std::unordered_map<std::string, std::string> environment = invocation.environment();
+                    environment.insert(processContext->environmentVariables().begin(), processContext->environmentVariables().end());
+
                     process::MemoryContext context = process::MemoryContext(
                         *path,
                         invocation.workingDirectory(),
                         invocation.arguments(),
-                        invocation.environment(),
+                        environment,
                         processContext->userID(),
                         processContext->groupID(),
                         processContext->userName(),

--- a/Libraries/xcsdk/Sources/SDK/Manager.cpp
+++ b/Libraries/xcsdk/Sources/SDK/Manager.cpp
@@ -119,6 +119,7 @@ executablePaths() const
 {
     return {
         _path + "/usr/bin",
+        _path + "/usr/local/bin",
         _path + "/Tools",
     };
 }

--- a/Libraries/xcsdk/Sources/SDK/Platform.cpp
+++ b/Libraries/xcsdk/Sources/SDK/Platform.cpp
@@ -150,7 +150,12 @@ settings() const
 std::vector<std::string> Platform::
 executablePaths() const
 {
-    return { _path + "/Developer/usr/bin" };
+    return {
+        _path + "/Developer/usr/bin",
+        _path + "/usr/local/bin",
+        _path + "/usr/bin",
+        _path + "/usr/local/bin",
+    };
 }
 
 bool Platform::

--- a/Libraries/xcsdk/Sources/SDK/Toolchain.cpp
+++ b/Libraries/xcsdk/Sources/SDK/Toolchain.cpp
@@ -35,7 +35,10 @@ Toolchain::
 std::vector<std::string> Toolchain::
 executablePaths() const
 {
-    return { _path + "/usr/bin" };
+    return {
+        _path + "/usr/bin",
+        _path + "/usr/libexec",
+    };
 }
 
 bool Toolchain::


### PR DESCRIPTION
 - Include all necessary paths in tool search paths.
 - Set `PATH` to match the paths searched for tools.
 - Set `DEVELOPER_DIR` for all invocations to stay self-contained.
 - Pass along process environment to tools rather than clearing.

My version of #169. @onhachoe, would be great if you could test with the case you were seeing `PATH` being important.