### PR TITLE
Fix xcode build file parsing

### DIFF
--- a/Libraries/pbxsetting/Sources/XC/Config.cpp
+++ b/Libraries/pbxsetting/Sources/XC/Config.cpp
@@ -153,8 +153,10 @@ Load(Filesystem const *filesystem, Environment const &environment, std::string c
         if (c == '/') {
             if (slash) {
                 /* Two slashes, start comment. */
-                line.pop_back();
-                comment = true;
+                if (!comment) {
+                    line.pop_back();
+                    comment = true;
+                }
             } else {
                 /* One slash, prepare for comment. */
                 slash = true;


### PR DESCRIPTION
Currently, build file parsing would break when encounterd with something like

    // some comment //

fix this.