### PR TITLE
[process] Capture stdout/stderr in DefaultLauncher

### DIFF
--- a/Libraries/process/CMakeLists.txt
+++ b/Libraries/process/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(process SHARED
             Sources/DefaultContext.cpp
             Sources/MemoryContext.cpp
             Sources/Launcher.cpp
+            Sources/LaunchResult.cpp
             Sources/DefaultLauncher.cpp
             Sources/MemoryLauncher.cpp
             )
@@ -22,3 +23,7 @@ install(TARGETS process DESTINATION usr/lib)
 
 find_package(Threads REQUIRED)
 target_link_libraries(process PRIVATE ${CMAKE_THREAD_LIBS_INIT})
+
+if (BUILD_TESTING)
+  ADD_UNIT_GTEST(process DefaultLauncher Tests/test_DefaultLauncher.cpp)
+endif ()

--- a/Libraries/process/Headers/process/DefaultLauncher.h
+++ b/Libraries/process/Headers/process/DefaultLauncher.h
@@ -16,6 +16,8 @@ namespace libutil { class Filesystem; }
 
 namespace process {
 
+class LaunchResult;
+
 /*
  * Abstract process launcher.
  */
@@ -25,7 +27,8 @@ public:
     ~DefaultLauncher();
 
 public:
-    virtual ext::optional<int> launch(libutil::Filesystem *filesystem, Context const *context);
+    virtual ext::optional<LaunchResult> launch(libutil::Filesystem *filesystem,
+                                               Context const *context);
 };
 
 }

--- a/Libraries/process/Headers/process/LaunchResult.h
+++ b/Libraries/process/Headers/process/LaunchResult.h
@@ -1,0 +1,50 @@
+/**
+ Copyright (c) 2015-present, Facebook, Inc.
+ All rights reserved.
+
+ This source code is licensed under the BSD-style license found in the
+ LICENSE file in the root directory of this source tree. An additional grant
+ of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#ifndef __process_LaunchResult_h
+#define __process_LaunchResult_h
+
+#include <process/Context.h>
+
+#include <sstream>
+#include <ext/optional>
+
+namespace libutil { class Filesystem; }
+
+namespace process {
+
+/*
+ * The result of a successfully launched process: its exit code and output.
+ */
+class LaunchResult {
+private:
+    int _exitCode;
+    std::string _standardOutput;
+    std::string _standardError;
+
+public:
+    LaunchResult(
+        int exitCode,
+        std::string const &standardOutput,
+        std::string const &standardError);
+    ~LaunchResult();
+
+    int exitCode() const
+    { return _exitCode; }
+
+    std::string const &standardOutput() const
+    { return _standardOutput; }
+
+    std::string const &standardError() const
+    { return _standardError; }
+};
+
+}
+
+#endif  // !__process_LaunchResult_h

--- a/Libraries/process/Headers/process/Launcher.h
+++ b/Libraries/process/Headers/process/Launcher.h
@@ -19,6 +19,8 @@ namespace libutil { class Filesystem; }
 
 namespace process {
 
+class LaunchResult;
+
 /*
  * Abstract process launcher.
  */
@@ -32,7 +34,8 @@ public:
      * Launch and wait for a process. The filesystem is symbolic, to note
      * that launching a process could arbitrarily affect the filesystem.
      */
-    virtual ext::optional<int> launch(libutil::Filesystem *filesystem, Context const *context) = 0;
+    virtual ext::optional<LaunchResult> launch(libutil::Filesystem *filesystem,
+                                               Context const *context) = 0;
 };
 
 }

--- a/Libraries/process/Headers/process/MemoryLauncher.h
+++ b/Libraries/process/Headers/process/MemoryLauncher.h
@@ -14,6 +14,8 @@
 
 namespace process {
 
+class LaunchResult;
+
 /*
  * In-memory simulated process launcher.
  */
@@ -22,7 +24,8 @@ public:
     /*
      * Handler for a simulated process launch.
      */
-    using Handler = std::function<ext::optional<int>(libutil::Filesystem *filesystem, Context const *context)>;
+    using Handler = std::function<ext::optional<LaunchResult>(libutil::Filesystem *filesystem,
+                                                              Context const *context)>;
 
 private:
     std::unordered_map<std::string, Handler> _handlers;
@@ -32,7 +35,8 @@ public:
     ~MemoryLauncher();
 
 public:
-    virtual ext::optional<int> launch(libutil::Filesystem *filesystem, Context const *context);
+    virtual ext::optional<LaunchResult> launch(libutil::Filesystem *filesystem,
+                                               Context const *context);
 };
 
 }

--- a/Libraries/process/Sources/LaunchResult.cpp
+++ b/Libraries/process/Sources/LaunchResult.cpp
@@ -1,0 +1,30 @@
+/**
+ Copyright (c) 2015-present, Facebook, Inc.
+ All rights reserved.
+
+ This source code is licensed under the BSD-style license found in the
+ LICENSE file in the root directory of this source tree. An additional grant
+ of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#include <process/LaunchResult.h>
+
+using process::LaunchResult;
+
+LaunchResult::
+LaunchResult(
+    int exitCode,
+    std::string const &standardOutput,
+    std::string const &standardError) :
+    _exitCode      (exitCode),
+    _standardOutput(standardOutput),
+    _standardError (standardError)
+{
+}
+
+LaunchResult::
+~LaunchResult()
+{
+}
+
+

--- a/Libraries/process/Sources/MemoryLauncher.cpp
+++ b/Libraries/process/Sources/MemoryLauncher.cpp
@@ -8,9 +8,11 @@
  */
 
 #include <process/MemoryLauncher.h>
+#include <process/LaunchResult.h>
 #include <libutil/Filesystem.h>
 
 using process::MemoryLauncher;
+using process::LaunchResult;
 using libutil::Filesystem;
 
 MemoryLauncher::
@@ -25,7 +27,7 @@ MemoryLauncher::
 {
 }
 
-ext::optional<int> MemoryLauncher::
+ext::optional<LaunchResult> MemoryLauncher::
 launch(Filesystem *filesystem, Context const *context)
 {
     auto it = _handlers.find(context->executablePath());

--- a/Libraries/process/Tests/test_DefaultLauncher.cpp
+++ b/Libraries/process/Tests/test_DefaultLauncher.cpp
@@ -1,0 +1,41 @@
+/**
+ Copyright (c) 2015-present, Facebook, Inc.
+ All rights reserved.
+
+ This source code is licensed under the BSD-style license found in the
+ LICENSE file in the root directory of this source tree. An additional grant
+ of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#include <gtest/gtest.h>
+#include <process/DefaultLauncher.h>
+#include <process/LaunchResult.h>
+#include <process/MemoryContext.h>
+#include <libutil/DefaultFilesystem.h>
+
+#include <unistd.h>
+
+using process::DefaultLauncher;
+using process::MemoryContext;
+using libutil::DefaultFilesystem;
+
+TEST(DefaultLauncher, CapturesStdout)
+{
+    DefaultLauncher launcher;
+    auto filesystem = DefaultFilesystem::GetDefaultUNSAFE();
+
+    std::unordered_map<std::string, std::string> environment;
+    auto echo = MemoryContext(
+        "/bin/echo",
+        "/",
+        { "foo" },
+        std::unordered_map<std::string, std::string>(),
+        ::getuid(),
+        ::getgid(),
+        "user",
+        "group");
+    auto result = launcher.launch(filesystem, &echo);
+    EXPECT_TRUE(result);
+    EXPECT_EQ(0, result->exitCode());
+    EXPECT_EQ("foo\n", (*result).standardOutput());
+}

--- a/Libraries/xcexecution/Sources/NinjaExecutor.cpp
+++ b/Libraries/xcexecution/Sources/NinjaExecutor.cpp
@@ -21,6 +21,7 @@
 #include <process/Context.h>
 #include <process/MemoryContext.h>
 #include <process/Launcher.h>
+#include <process/LaunchResult.h>
 #include <libutil/md5.h>
 
 #include <sstream>
@@ -462,8 +463,8 @@ build(
             processContext->userName(),
             processContext->groupName());
 
-        ext::optional<int> exitCode = processLauncher->launch(filesystem, &ninja);
-        if (!exitCode || *exitCode != 0) {
+        auto result = processLauncher->launch(filesystem, &ninja);
+        if (!result || result->exitCode() != 0) {
             return false;
         }
     }

--- a/Libraries/xcexecution/Sources/SimpleExecutor.cpp
+++ b/Libraries/xcexecution/Sources/SimpleExecutor.cpp
@@ -18,6 +18,7 @@
 #include <process/Context.h>
 #include <process/MemoryContext.h>
 #include <process/Launcher.h>
+#include <process/LaunchResult.h>
 
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -291,8 +292,8 @@ performInvocations(
                         processContext->groupID(),
                         processContext->userName(),
                         processContext->groupName());
-                    ext::optional<int> exitCode = processLauncher->launch(filesystem, &context);
-                    success = (exitCode && *exitCode == 0);
+                    auto result = processLauncher->launch(filesystem, &context);
+                    success = (result && result->exitCode() == 0);
 
                     xcformatter::Formatter::Print(_formatter->finishInvocation(invocation, *path, createProductStructure));
                 } else {

--- a/Libraries/xcexecution/Tests/test_SimpleExecutor.cpp
+++ b/Libraries/xcexecution/Tests/test_SimpleExecutor.cpp
@@ -13,6 +13,7 @@
 #include <pbxbuild/Tool/Invocation.h>
 #include <builtin/Driver.h>
 #include <builtin/Registry.h>
+#include <process/LaunchResult.h>
 #include <process/MemoryContext.h>
 #include <process/MemoryLauncher.h>
 #include <libutil/MemoryFilesystem.h>
@@ -54,11 +55,11 @@ TEST(SimpleExecutor, PropagateToolResult)
     });
 
     auto launcher = process::MemoryLauncher({
-        { "/fail-tool", [](Filesystem *filesystem, process::Context const *context) -> ext::optional<int> {
-            return 1;
+        { "/fail-tool", [](Filesystem *filesystem, process::Context const *context) -> ext::optional<process::LaunchResult> {
+            return process::LaunchResult(1, "", "");
         } },
-        { "/success-tool", [](Filesystem *filesystem, process::Context const *context) -> ext::optional<int> {
-            return 0;
+        { "/success-tool", [](Filesystem *filesystem, process::Context const *context) -> ext::optional<process::LaunchResult> {
+            return process::LaunchResult(0, "", "");
         } },
     });
 

--- a/Libraries/xcsdk/Tools/xcrun.cpp
+++ b/Libraries/xcsdk/Tools/xcrun.cpp
@@ -19,6 +19,7 @@
 #include <process/DefaultContext.h>
 #include <process/MemoryContext.h>
 #include <process/Launcher.h>
+#include <process/LaunchResult.h>
 #include <process/DefaultLauncher.h>
 #include <pbxsetting/Type.h>
 
@@ -451,13 +452,13 @@ static int Run(Filesystem *filesystem, process::Context const *processContext, p
                 processContext->userName(),
                 processContext->groupName());
 
-            ext::optional<int> exitCode = processLauncher->launch(filesystem, &context);
-            if (!exitCode) {
+            auto result = processLauncher->launch(filesystem, &context);
+            if (!result) {
                 fprintf(stderr, "error: unable to execute tool '%s'\n", options.tool()->c_str());
                 return -1;
             }
 
-            return *exitCode;
+            return result->exitCode();
         }
     }
 }


### PR DESCRIPTION
== What's in this change? ==

* Modify the Launcher API such that it can return not only an exit code, but the stdout and stderr output as well.
* Modify DefaultLauncher such that it captures and returns stdout and stderr.

== Why make this change? ==

I'm working on adding an implementation of `swift-stdlib-tool` to xcbuild. This tool is expected to, among other things, scan object files in order to determine whether they contain references to the Swift runtime. In order to implement this logic in xcbuild, I could write C++ code that scans the object files, or I could use existing tools that do so. It's my intention to shell out to these existing tools, but
to do so I'd need to:

1. Find the appropriate tool by running `xcrun -find` and capturing its output.
2. Running the tool found by step (1) and capturing its output. I'd then scan the output for text that indicates a Swift runtime dependency.

And so I need a utility in xcbuild that can capture output from launched processes, which is what this change adds.

---

I haven't written very much C++, so please let me know if there's something I can improve upon here. Thanks!