### PR TITLE
Fixes to make swift project work correctly and fixes to ninja execution path.

### DIFF
--- a/Libraries/pbxbuild/Headers/pbxbuild/Tool/Invocation.h
+++ b/Libraries/pbxbuild/Headers/pbxbuild/Tool/Invocation.h
@@ -110,6 +110,9 @@ private:
 private:
     bool                                         _createsProductStructure;
 
+private:
+    bool                                         _waitForSwiftArtifacts;
+
 public:
     Invocation();
     ~Invocation();
@@ -194,6 +197,14 @@ public:
 public:
     bool &createsProductStructure()
     { return _createsProductStructure; }
+
+public:
+    bool waitForSwiftArtifacts() const
+    { return _waitForSwiftArtifacts; }
+
+public:
+    bool &waitForSwiftArtifacts()
+    { return _waitForSwiftArtifacts; }
 };
 
 }

--- a/Libraries/pbxbuild/Headers/pbxbuild/Tool/SwiftModuleInfo.h
+++ b/Libraries/pbxbuild/Headers/pbxbuild/Tool/SwiftModuleInfo.h
@@ -33,6 +33,9 @@ private:
 private:
     bool        _installHeader;
 
+private:
+    std::vector<std::string> _copiedArtifacts;
+
 public:
     SwiftModuleInfo(
         std::string const &architecture,
@@ -81,6 +84,13 @@ public:
      */
     bool installHeader() const
     { return _installHeader; }
+
+public:
+    /*
+     * List of artifacts copied at time of CopySwiftModules call.
+     */
+    std::vector<std::string> &copiedArtifacts()
+    { return _copiedArtifacts; }
 };
 
 }

--- a/Libraries/pbxbuild/Sources/Phase/SwiftResolver.cpp
+++ b/Libraries/pbxbuild/Sources/Phase/SwiftResolver.cpp
@@ -64,7 +64,7 @@ ShouldBundleSwiftRuntime(Tool::Context const *toolContext, pbxsetting::Environme
      * Need a place to put the runtime libraries. If the product is not a wrapper, then
      * there isn't a frameworks directory to include Swift in.
      */
-    if (productType->isWrapper()) {
+    if (!productType->isWrapper()) {
         return false;
     }
 

--- a/Libraries/pbxbuild/Sources/Tool/ClangResolver.cpp
+++ b/Libraries/pbxbuild/Sources/Tool/ClangResolver.cpp
@@ -289,6 +289,8 @@ resolveSource(
     invocation.inputDependencies() = inputDependencies;
     invocation.dependencyInfo() = dependencyInfo;
     invocation.logMessage() = logMessage;
+    // Wait for swift artifacts to be available before running this invocation
+    invocation.waitForSwiftArtifacts() = true;
 
     /* Add the compilation invocation to the context. */
     toolContext->invocations().push_back(invocation);

--- a/Libraries/pbxbuild/Sources/Tool/Invocation.cpp
+++ b/Libraries/pbxbuild/Sources/Tool/Invocation.cpp
@@ -66,7 +66,8 @@ Determine(std::string const &executable)
 Tool::Invocation::
 Invocation() :
     _showEnvironmentInLog   (true),
-    _createsProductStructure(false)
+    _createsProductStructure(false),
+    _waitForSwiftArtifacts  (false)
 {
 }
 

--- a/Libraries/xcexecution/Headers/xcexecution/NinjaExecutor.h
+++ b/Libraries/xcexecution/Headers/xcexecution/NinjaExecutor.h
@@ -64,7 +64,9 @@ private:
     bool buildAuxiliaryFile(
         ninja::Writer *writer,
         pbxbuild::Tool::AuxiliaryFile const &auxiliaryFile,
-        std::string const &after);
+        std::string const &after,
+        std::string const &temporaryDirectory,
+        std::map<std::string, pbxbuild::Tool::AuxiliaryFile::Chunk const *> &auxiliaryFileChunks);
     bool buildInvocation(
         ninja::Writer *writer,
         pbxbuild::Tool::Invocation const &invocation,

--- a/Libraries/xcexecution/Sources/NinjaExecutor.cpp
+++ b/Libraries/xcexecution/Sources/NinjaExecutor.cpp
@@ -97,7 +97,7 @@ NinjaDescription(std::string const &description)
 }
 
 static std::string
-NinjaHashInternal(const char *data, size_t size)
+NinjaHash(char const *data, size_t size)
 {
     md5_state_t state;
     md5_init(&state);
@@ -112,12 +112,6 @@ NinjaHashInternal(const char *data, size_t size)
     }
 
     return ss.str();
-}
-
-static std::string
-NinjaHash(std::string const &input)
-{
-    return NinjaHashInternal(input.data(), input.size());
 }
 
 static ext::optional<std::string>
@@ -193,7 +187,7 @@ NinjaInvocationPhonyOutput(pbxbuild::Tool::Invocation const &invocation)
         key += " " + arg;
     }
 
-    return ".ninja-phony-output-" + NinjaHash(key);
+    return ".ninja-phony-output-" + NinjaHash(key.data(), key.size());
 }
 
 static std::vector<std::string>
@@ -796,7 +790,7 @@ buildAuxiliaryFile(
         switch (chunk.type()) {
             case pbxbuild::Tool::AuxiliaryFile::Chunk::Type::Data: {
                 // Cache auxiliary file path and data, so that we can write them in build directory later.
-                const std::string auxiliaryFileChunkPath = temporaryDirectory + "/" + ".ninja-auxiliary-file-" + NinjaHashInternal(reinterpret_cast<const char *>(chunk.data()->data()), chunk.data()->size()) + ".chunk";
+                const std::string auxiliaryFileChunkPath = temporaryDirectory + "/" + ".ninja-auxiliary-file-" + NinjaHash(reinterpret_cast<const char *>(chunk.data()->data()), chunk.data()->size()) + ".chunk";
                 auxiliaryFileChunks.insert(std::make_pair(auxiliaryFileChunkPath, &chunk));
                 exec += "cat " + Escape::Shell(auxiliaryFileChunkPath);
                 inputs.push_back(ninja::Value::String(auxiliaryFileChunkPath));
@@ -883,7 +877,7 @@ buildInvocation(
         std::string output = NinjaInvocationOutputs(invocation).front();
 
         /* Find where the generated dependency info should go. */
-        dependencyInfoFile = temporaryDirectory + "/" + ".ninja-dependency-info-" + NinjaHash(output) + ".d";
+        dependencyInfoFile = temporaryDirectory + "/" + ".ninja-dependency-info-" + NinjaHash(output.data(), output.size()) + ".d";
 
         /* Build the dependency info rewriter arguments. */
         std::vector<std::string> dependencyInfoArguments = {

--- a/Libraries/xcsdk/Sources/SDK/Toolchain.cpp
+++ b/Libraries/xcsdk/Sources/SDK/Toolchain.cpp
@@ -60,6 +60,9 @@ parse(plist::Dictionary const *dict)
     auto PSV  = unpack.coerce <plist::Boolean> ("ProvidesSwiftVersion");
     auto OBS  = unpack.cast <plist::Dictionary> ("OverrideBuildSettings");
 
+    /* Ignored */
+    (void)unpack.cast <plist::String> ("DTSDKBuild");
+
     if (!unpack.complete(true)) {
         fprintf(stderr, "%s", unpack.errorText().c_str());
     }

--- a/Specifications/Tool/CMakeLists.txt
+++ b/Specifications/Tool/CMakeLists.txt
@@ -10,6 +10,7 @@
 install(FILES
         com.apple.build-tools.nmedit.xcspec
         com.apple.build-tools.strip.xcspec
+        com.apple.build-tools.swift-stdlib-tool.xcspec
         com.apple.commands.built-in.compilation-database-generator.xcspec
         com.apple.commands.built-in.headermap-generator.xcspec
         com.apple.commands.built-in.validate.xcspec

--- a/Specifications/Tool/com.apple.build-tools.swift-stdlib-tool.xcspec
+++ b/Specifications/Tool/com.apple.build-tools.swift-stdlib-tool.xcspec
@@ -1,0 +1,115 @@
+/**
+ Copyright (c) 2015-present, Facebook, Inc.
+ All rights reserved.
+
+ This source code is licensed under the BSD-style license found in the
+ LICENSE file in the root directory of this source tree. An additional grant
+ of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+{
+    Type = Tool;
+    Identifier = com.apple.build-tools.swift-stdlib-tool;
+    Name = "Swift stdlib tool";
+
+    /* TODO: Need swift-stdlib-tool to construct valid command line. */
+    CommandLine = "builtin-swiftStdLibTool [options]";
+    RuleName = "CopySwiftLibs $(OutputPath)";
+
+    DeeplyStatInputDirectories = YES;
+    Outputs = (
+        "$(OutputPath)",
+    );
+
+	Options = (
+        {
+            Name = "SWIFT_STDLIB_TOOL_ACTION";
+            CommandLineArgs = ( "--copy" );
+        },
+        {
+            Name = "SWIFT_STDLIB_TOOL_VERBOSITY";
+            Type = Enumeration;
+            Values = (
+                none,
+                verbose,
+            );
+            DefaultValue = "verbose";
+            CommandLineArgs = {
+                none = ();
+                verbose = (
+                    "--verbose",
+                );
+            };
+        },
+		{
+            Name = "SWIFT_STDLIB_TOOL_EXECUTABLE_TO_SCAN";
+            Type = Path;
+            DefaultValue = "$(InputPath)";
+            CommandLineFlag = "--scan-executable";
+		},
+		{
+            Name = "SWIFT_STDLIB_TOOL_FOLDERS_TO_SCAN";
+            Type = PathList;
+            DefaultValue = "";
+            CommandLineFlag = "--scan-folder";
+		},
+        {
+            Name = "SWIFT_STDLIB_TOOL_SOURCE_LIBRARIES";
+            Type = Path;
+            DefaultValue = "$(SWIFT_LIBRARY_PATH)";
+            CommandLineArgs = {
+                "" = ( "--platform", "$(PLATFORM_NAME)" );
+                "<<otherwise>>" = ( "--source-libraries", "$(value)" );
+            };
+        },
+        {
+            Name = "SWIFT_STDLIB_TOOL_TOOLCHAINS";
+            Type = PathList;
+            DefaultValue = "$(EFFECTIVE_TOOLCHAINS_DIRS)";
+            CommandLineFlag = "--toolchain";
+        },
+        {
+            Name = "SWIFT_STDLIB_TOOL_DESTINATION_DIR";
+            Type = Path;
+            DefaultValue = "$(TARGET_BUILD_DIR)/$(FRAMEWORKS_FOLDER_PATH)";
+            CommandLineFlag = "--destination";
+        },
+        {
+            Name = "SWIFT_STDLIB_TOOL_STRIP_BITCODE";
+            Type = Boolean;
+            DefaultValue = YES;
+            CommandLineFlag = "--strip-bitcode";
+            Condition = "$(ENABLE_BITCODE) == NO  ||  $(BITCODE_GENERATION_MODE) != bitcode";
+        },
+        {
+            Name = "SWIFT_STDLIB_TOOL_RESOURCE_DESTINATION";
+            Type = Path;
+            DefaultValue = "$(TARGET_BUILD_DIR)/$(UNLOCALIZED_RESOURCES_FOLDER_PATH)";
+            CommandLineFlag = "--resource-destination";
+            Condition = "$(DEPLOYMENT_POSTPROCESSING) == NO";
+        },
+        {
+            Name = "SWIFT_STDLIB_TOOL_RESOURCE_LIBRARY";
+            Type = StringList;
+            DefaultValue = "libswiftRemoteMirror.dylib";
+            CommandLineFlag = "--resource-library";
+            Condition = "$(DEPLOYMENT_POSTPROCESSING) == NO";
+        },
+        {
+            Name = TOOLCHAINS;
+            Type = StringList;
+            SetValueInEnvironmentVariable = TOOLCHAINS;
+        },
+        {
+            Name = SDKROOT;
+            Type = Path;
+            SetValueInEnvironmentVariable = SDKROOT;
+        },
+        {
+            Name = DEVELOPER_DIR;
+            Type = Path;
+            SetValueInEnvironmentVariable = DEVELOPER_DIR;
+        },
+    );
+}
+

--- a/Specifications/Tool/com.apple.build-tools.swift-stdlib-tool.xcspec
+++ b/Specifications/Tool/com.apple.build-tools.swift-stdlib-tool.xcspec
@@ -32,11 +32,16 @@
             Values = (
                 none,
                 verbose,
+                extra-verbose,
             );
             DefaultValue = "verbose";
             CommandLineArgs = {
                 none = ();
                 verbose = (
+                    "--verbose",
+                );
+                extra-verbose = (
+                    "--verbose",
                     "--verbose",
                 );
             };


### PR DESCRIPTION
This includes 4 commits

Compile swift before any other clang invocation
 - Swift compilation first before objc compilation.
 - Fixes issue address on #237 

Slight refactoring of PhaseInvocation resolving step
 - as title

Refactor builtin tool resolving in NinjaExecutor
 - Fixes to make symlinked xcbuild work properly

Refactor auxiliary file creation path for ninja
 - Auxiliary file handling improvements.

Add Swift Standard Library tool xcspec
 - swift-stdlib-tool xcspec to copy over swift libraries