### PR TITLE
Process contents inside child directories first in Filesystem->readDirectory call

### DIFF
--- a/Libraries/dependency/Tests/test_DirectoryDependencyInfo.cpp
+++ b/Libraries/dependency/Tests/test_DirectoryDependencyInfo.cpp
@@ -32,8 +32,8 @@ TEST(DirectoryDependencyInfo, Deserialize)
     EXPECT_EQ(info->dependencyInfo().inputs(), std::vector<std::string>({
         "/root/file1",
         "/root/file2",
-        "/root/dir",
         "/root/dir/file3",
+        "/root/dir",
     }));
     EXPECT_TRUE(info->dependencyInfo().outputs().empty());
 }

--- a/Libraries/libutil/Sources/DefaultFilesystem.cpp
+++ b/Libraries/libutil/Sources/DefaultFilesystem.cpp
@@ -494,28 +494,19 @@ readDirectory(std::string const &path, bool recursive, std::function<void(std::s
             }
 
             std::string path = (relative ? *relative + "/" + entry->d_name : entry->d_name);
-            cb(path);
-        }
 
-        /* Process subdirectories. */
-        if (recursive) {
-            ::rewinddir(dp);
-
-            while (struct dirent *entry = ::readdir(dp)) {
-                if (::strcmp(entry->d_name, ".") == 0 || ::strcmp(entry->d_name, "..") == 0) {
-                    continue;
-                }
-
+            /* Process subdirectories first. */
+            if (recursive) {
                 std::string full = absolute + "/" + entry->d_name;
-
                 if (this->type(full) == Type::Directory) {
-                    std::string path = (relative ? *relative + "/" + entry->d_name : entry->d_name);
                     if (!process(full, path)) {
                         ::closedir(dp);
                         return false;
                     }
                 }
             }
+
+            cb(path);
         }
 
         ::closedir(dp);

--- a/Libraries/libutil/Sources/MemoryFilesystem.cpp
+++ b/Libraries/libutil/Sources/MemoryFilesystem.cpp
@@ -385,17 +385,13 @@ readDirectory(std::string const &path, bool recursive, std::function<void(std::s
         /* Report children. */
         for (MemoryFilesystem::Entry const &child : entry->children()) {
             std::string path = (subpath ? *subpath + "/" + child.name() : child.name());
-            cb(path);
-        }
 
-        /* Process subdirectories. */
-        if (recursive) {
-            for (MemoryFilesystem::Entry const &child : entry->children()) {
-                if (child.type() == Type::Directory) {
-                    std::string path = (subpath ? *subpath + "/" + child.name() : child.name());
-                    process(path, &child);
-                }
+            /* Process subdirectories first. */
+            if (recursive) {
+                process(path, &child);
             }
+
+            cb(path);
         }
     };
 

--- a/Libraries/libutil/Tests/test_MemoryFilesystem.cpp
+++ b/Libraries/libutil/Tests/test_MemoryFilesystem.cpp
@@ -302,7 +302,7 @@ TEST(MemoryFilesystem, ReadDirectory)
     /* List root contents, recursive. */
     files.clear();
     EXPECT_TRUE(filesystem.readDirectory("/", true, accumulate));
-    EXPECT_EQ(files, std::vector<std::string>({ "file1", "dir1", "dir2", "dir1/file2", "dir2/file2", "dir2/dir3" }));
+    EXPECT_EQ(files, std::vector<std::string>({ "file1", "dir1/file2", "dir1", "dir2/file2", "dir2/dir3", "dir2" }));
 
     /* List file. */
     files.clear();


### PR DESCRIPTION
This fixes case when Filesystem->removeDirectory() call is invoked with recursive option set to true.