### PR TITLE
Make build order respect phase ordering on build target.

### DIFF
--- a/Libraries/pbxbuild/Headers/pbxbuild/Tool/Context.h
+++ b/Libraries/pbxbuild/Headers/pbxbuild/Tool/Context.h
@@ -24,6 +24,9 @@
 #include <string>
 #include <vector>
 
+#define PHASE_INVOCATION_PRIORITY_BASE 0x100
+#define PHASE_INVOCATION_PRIORITY_INCREMENT 0x100
+
 namespace pbxbuild {
 namespace Tool {
 
@@ -49,6 +52,9 @@ private:
 
 private:
     std::vector<Tool::AuxiliaryFile> _auxiliaryFiles;
+
+private:
+    uint32_t                         _currentPhaseInvocationPriority;
 
 public:
     Context(
@@ -113,6 +119,15 @@ public:
 public:
     std::vector<Tool::AuxiliaryFile> &auxiliaryFiles()
     { return _auxiliaryFiles; }
+
+public:
+    uint32_t currentPhaseInvocationPriority() const
+    { return _currentPhaseInvocationPriority; }
+
+public:
+    uint32_t &currentPhaseInvocationPriority()
+    { return _currentPhaseInvocationPriority; }
+
 };
 
 }

--- a/Libraries/pbxbuild/Headers/pbxbuild/Tool/Invocation.h
+++ b/Libraries/pbxbuild/Headers/pbxbuild/Tool/Invocation.h
@@ -113,6 +113,9 @@ private:
 private:
     bool                                         _waitForSwiftArtifacts;
 
+private:
+    uint32_t                                     _priority;
+
 public:
     Invocation();
     ~Invocation();
@@ -205,6 +208,14 @@ public:
 public:
     bool &waitForSwiftArtifacts()
     { return _waitForSwiftArtifacts; }
+
+public:
+    uint32_t priority() const
+    { return _priority; }
+
+public:
+    uint32_t &priority()
+    { return _priority; }
 };
 
 }

--- a/Libraries/pbxbuild/Sources/Phase/PhaseInvocations.cpp
+++ b/Libraries/pbxbuild/Sources/Phase/PhaseInvocations.cpp
@@ -91,7 +91,10 @@ Create(Phase::Environment const &phaseEnvironment, pbxproj::PBX::Target::shared_
     /*
      * Resolve all build phases.
      */
+    phaseContext.toolContext().currentPhaseInvocationPriority() = PHASE_INVOCATION_PRIORITY_BASE;
+    uint32_t targetLevelPhaseInsertionPoint = phaseContext.toolContext().currentPhaseInvocationPriority();
     for (pbxproj::PBX::BuildPhase::shared_ptr const &buildPhase : buildPhases) {
+        bool updateTargetLevelPhaseInsertionPoint = false;
         switch (buildPhase->type()) {
             case pbxproj::PBX::BuildPhase::Type::Sources: {
                 auto BP = std::static_pointer_cast <pbxproj::PBX::SourcesBuildPhase> (buildPhase);
@@ -100,6 +103,8 @@ Create(Phase::Environment const &phaseEnvironment, pbxproj::PBX::Target::shared_
                 if (!sources.resolve(phaseEnvironment, &phaseContext)) {
                     fprintf(stderr, "error: unable to resolve sources\n");
                 }
+
+                updateTargetLevelPhaseInsertionPoint = true;
                 break;
             }
             case pbxproj::PBX::BuildPhase::Type::Frameworks: {
@@ -109,6 +114,8 @@ Create(Phase::Environment const &phaseEnvironment, pbxproj::PBX::Target::shared_
                 if (!frameworks.resolve(phaseEnvironment, &phaseContext)) {
                     fprintf(stderr, "error: unable to resolve linking\n");
                 }
+
+                updateTargetLevelPhaseInsertionPoint = true;
                 break;
             }
             case pbxproj::PBX::BuildPhase::Type::ShellScript: {
@@ -127,6 +134,8 @@ Create(Phase::Environment const &phaseEnvironment, pbxproj::PBX::Target::shared_
                 if (!copyFiles.resolve(phaseEnvironment, &phaseContext)) {
                     fprintf(stderr, "error: unable to resolve copy files\n");
                 }
+
+                updateTargetLevelPhaseInsertionPoint = true;
                 break;
             }
             case pbxproj::PBX::BuildPhase::Type::Headers: {
@@ -136,6 +145,8 @@ Create(Phase::Environment const &phaseEnvironment, pbxproj::PBX::Target::shared_
                 if (!headers.resolve(phaseEnvironment, &phaseContext)) {
                     fprintf(stderr, "error: unable to resolve headers\n");
                 }
+
+                updateTargetLevelPhaseInsertionPoint = true;
                 break;
             }
             case pbxproj::PBX::BuildPhase::Type::Resources: {
@@ -145,6 +156,8 @@ Create(Phase::Environment const &phaseEnvironment, pbxproj::PBX::Target::shared_
                 if (!resources.resolve(phaseEnvironment, &phaseContext)) {
                     fprintf(stderr, "error: unable to resolve resources\n");
                 }
+
+                updateTargetLevelPhaseInsertionPoint = true;
                 break;
             }
             case pbxproj::PBX::BuildPhase::Type::AppleScript: {
@@ -158,7 +171,31 @@ Create(Phase::Environment const &phaseEnvironment, pbxproj::PBX::Target::shared_
                 break;
             }
         }
+
+        phaseContext.toolContext().currentPhaseInvocationPriority() += PHASE_INVOCATION_PRIORITY_INCREMENT;
+
+        /*
+         * At the end of iteration, every invocation with priority equal to or greater than
+         * targetLevelPhaseInsertionPoint will be bumped up to next priority level to accomodate
+         * room for target level phase invocations.
+         */
+        if (updateTargetLevelPhaseInsertionPoint) {
+            targetLevelPhaseInsertionPoint = std::max(
+                targetLevelPhaseInsertionPoint,
+                phaseContext.toolContext().currentPhaseInvocationPriority()
+            );
+        }
     }
+
+    for (auto invocation : phaseContext.toolContext().invocations()) {
+        if (invocation.priority() >= targetLevelPhaseInsertionPoint) {
+            invocation.priority() += PHASE_INVOCATION_PRIORITY_INCREMENT;
+        }
+    }
+
+    /* Temporarily override phase invocation priority to add target level invocations */
+    uint32_t currentPhaseInvocationPriorityCache = phaseContext.toolContext().currentPhaseInvocationPriority();
+    phaseContext.toolContext().currentPhaseInvocationPriority() = targetLevelPhaseInsertionPoint;
 
     /*
      * Add target-level invocations. Note these must come last as they use the context values set
@@ -203,6 +240,9 @@ Create(Phase::Environment const &phaseEnvironment, pbxproj::PBX::Target::shared_
         case pbxproj::PBX::Target::Type::Aggregate:
             break;
     }
+
+    /* Restore current phase invocation priority level */
+    phaseContext.toolContext().currentPhaseInvocationPriority() = currentPhaseInvocationPriorityCache;
 
     return Phase::PhaseInvocations(phaseContext.toolContext().invocations(), phaseContext.toolContext().auxiliaryFiles());
 }

--- a/Libraries/pbxbuild/Sources/Tool/AssetCatalogResolver.cpp
+++ b/Libraries/pbxbuild/Sources/Tool/AssetCatalogResolver.cpp
@@ -126,6 +126,7 @@ resolve(
     invocation.outputs() = outputs;
     invocation.dependencyInfo() = dependencyInfo;
     invocation.logMessage() = tokens.logMessage();
+    invocation.priority() = toolContext->currentPhaseInvocationPriority();
     toolContext->invocations().push_back(invocation);
 }
 

--- a/Libraries/pbxbuild/Sources/Tool/ClangResolver.cpp
+++ b/Libraries/pbxbuild/Sources/Tool/ClangResolver.cpp
@@ -189,6 +189,7 @@ resolvePrecompiledHeader(
     invocation.outputs() = toolEnvironment.outputs(toolContext->workingDirectory());
     invocation.dependencyInfo() = dependencyInfo;
     invocation.logMessage() = logMessage;
+    invocation.priority() = toolContext->currentPhaseInvocationPriority();
     toolContext->invocations().push_back(invocation);
 
     toolContext->auxiliaryFiles().push_back(serializedFile);
@@ -289,6 +290,7 @@ resolveSource(
     invocation.inputDependencies() = inputDependencies;
     invocation.dependencyInfo() = dependencyInfo;
     invocation.logMessage() = logMessage;
+    invocation.priority() = toolContext->currentPhaseInvocationPriority();
     // Wait for swift artifacts to be available before running this invocation
     invocation.waitForSwiftArtifacts() = true;
 

--- a/Libraries/pbxbuild/Sources/Tool/Context.cpp
+++ b/Libraries/pbxbuild/Sources/Tool/Context.cpp
@@ -17,10 +17,11 @@ Context(
     std::vector<xcsdk::SDK::Toolchain::shared_ptr> const &toolchains,
     std::string const &workingDirectory,
     Tool::SearchPaths const &searchPaths) :
-    _sdk             (sdk),
-    _toolchains      (toolchains),
-    _workingDirectory(workingDirectory),
-    _searchPaths     (searchPaths)
+    _sdk                            (sdk),
+    _toolchains                     (toolchains),
+    _workingDirectory               (workingDirectory),
+    _searchPaths                    (searchPaths),
+    _currentPhaseInvocationPriority (0)
 {
 }
 

--- a/Libraries/pbxbuild/Sources/Tool/CopyResolver.cpp
+++ b/Libraries/pbxbuild/Sources/Tool/CopyResolver.cpp
@@ -94,6 +94,7 @@ resolve(
     invocation.outputs() = toolEnvironment.outputs(toolContext->workingDirectory());
     invocation.dependencyInfo() = dependencyInfo;
     invocation.logMessage() = tokens.logMessage();
+    invocation.priority() = toolContext->currentPhaseInvocationPriority();
     toolContext->invocations().push_back(invocation);
 }
 

--- a/Libraries/pbxbuild/Sources/Tool/DittoResolver.cpp
+++ b/Libraries/pbxbuild/Sources/Tool/DittoResolver.cpp
@@ -35,6 +35,7 @@ resolve(
     invocation.inputs() = { FSUtil::ResolveRelativePath(sourcePath, toolContext->workingDirectory()) };
     invocation.outputs() = { FSUtil::ResolveRelativePath(targetPath, toolContext->workingDirectory()) };
     invocation.logMessage() = logMessage;
+    invocation.priority() = toolContext->currentPhaseInvocationPriority();
     toolContext->invocations().push_back(invocation);
 }
 

--- a/Libraries/pbxbuild/Sources/Tool/InfoPlistResolver.cpp
+++ b/Libraries/pbxbuild/Sources/Tool/InfoPlistResolver.cpp
@@ -72,6 +72,7 @@ resolve(
     invocation.inputDependencies() = toolContext->additionalInfoPlistContents();
     invocation.logMessage() = tokens.logMessage();
     invocation.showEnvironmentInLog() = false; /* Hide build settings from log. */
+    invocation.priority() = toolContext->currentPhaseInvocationPriority();
     toolContext->invocations().push_back(invocation);
 }
 

--- a/Libraries/pbxbuild/Sources/Tool/InterfaceBuilderResolver.cpp
+++ b/Libraries/pbxbuild/Sources/Tool/InterfaceBuilderResolver.cpp
@@ -97,6 +97,7 @@ resolve(
     invocation.inputs() = toolEnvironment.inputs(toolContext->workingDirectory());
     invocation.outputs() = outputs;
     invocation.logMessage() = tokens.logMessage();
+    invocation.priority() = toolContext->currentPhaseInvocationPriority();
     toolContext->invocations().push_back(invocation);
 }
 

--- a/Libraries/pbxbuild/Sources/Tool/InterfaceBuilderStoryboardLinkerResolver.cpp
+++ b/Libraries/pbxbuild/Sources/Tool/InterfaceBuilderStoryboardLinkerResolver.cpp
@@ -79,6 +79,7 @@ resolve(
     invocation.inputs() = toolEnvironment.inputs(toolContext->workingDirectory());
     invocation.outputs() = outputs;
     invocation.logMessage() = tokens.logMessage();
+    invocation.priority() = toolContext->currentPhaseInvocationPriority();
     toolContext->invocations().push_back(invocation);
 }
 

--- a/Libraries/pbxbuild/Sources/Tool/LinkerResolver.cpp
+++ b/Libraries/pbxbuild/Sources/Tool/LinkerResolver.cpp
@@ -128,6 +128,7 @@ resolve(
     invocation.outputs() = toolEnvironment.outputs(toolContext->workingDirectory());
     invocation.dependencyInfo() = dependencyInfo;
     invocation.logMessage() = tokens.logMessage();
+    invocation.priority() = toolContext->currentPhaseInvocationPriority();
     toolContext->invocations().push_back(invocation);
 
     toolContext->auxiliaryFiles().insert(toolContext->auxiliaryFiles().end(), auxiliaries.begin(), auxiliaries.end());

--- a/Libraries/pbxbuild/Sources/Tool/MakeDirectoryResolver.cpp
+++ b/Libraries/pbxbuild/Sources/Tool/MakeDirectoryResolver.cpp
@@ -35,6 +35,7 @@ resolve(
     invocation.outputs() = { FSUtil::ResolveRelativePath(directory, toolContext->workingDirectory()) };
     invocation.logMessage() = "MkDir " + directory;
     invocation.createsProductStructure() = productStructure;
+    invocation.priority() = toolContext->currentPhaseInvocationPriority();
     toolContext->invocations().push_back(invocation);
 }
 

--- a/Libraries/pbxbuild/Sources/Tool/ScriptResolver.cpp
+++ b/Libraries/pbxbuild/Sources/Tool/ScriptResolver.cpp
@@ -75,6 +75,7 @@ resolve(
     invocation.environment() = environmentVariables;
     invocation.workingDirectory() = fullWorkingDirectory;
     invocation.logMessage() = logMessage;
+    invocation.priority() = toolContext->currentPhaseInvocationPriority();
     toolContext->invocations().push_back(invocation);
 }
 
@@ -124,6 +125,7 @@ resolve(
     invocation.outputs() = outputFiles;
     invocation.logMessage() = phaseEnvironment.expand(logMessage);
     invocation.showEnvironmentInLog() = buildPhase->showEnvVarsInLog();
+    invocation.priority() = toolContext->currentPhaseInvocationPriority();
     toolContext->invocations().push_back(invocation);
 
     toolContext->auxiliaryFiles().push_back(scriptFile);
@@ -187,6 +189,7 @@ resolve(
     invocation.outputs() = outputFiles;
     invocation.logMessage() = ruleEnvironment.expand(logMessage);
     invocation.showEnvironmentInLog() = true;
+    invocation.priority() = toolContext->currentPhaseInvocationPriority();
     toolContext->invocations().push_back(invocation);
 }
 

--- a/Libraries/pbxbuild/Sources/Tool/SwiftResolver.cpp
+++ b/Libraries/pbxbuild/Sources/Tool/SwiftResolver.cpp
@@ -404,6 +404,7 @@ resolve(
     invocation.outputs() = outputs;
     invocation.dependencyInfo() = dependencyInfo;
     invocation.logMessage() = logMessage;
+    invocation.priority() = toolContext->currentPhaseInvocationPriority();
     toolContext->invocations().push_back(invocation);
 
     auto variantArchitectureKey = std::make_pair(environment.resolve("variant"), environment.resolve("arch"));

--- a/Libraries/pbxbuild/Sources/Tool/SwiftStandardLibraryResolver.cpp
+++ b/Libraries/pbxbuild/Sources/Tool/SwiftStandardLibraryResolver.cpp
@@ -52,6 +52,7 @@ resolve(
     invocation.inputs() = toolEnvironment.inputs(toolContext->workingDirectory());
     invocation.outputs() = { }; // TODO(grp): Outputs are not known at build time.
     invocation.logMessage() = tokens.logMessage();
+    invocation.priority() = toolContext->currentPhaseInvocationPriority();
     toolContext->invocations().push_back(invocation);
 }
 

--- a/Libraries/pbxbuild/Sources/Tool/SymlinkResolver.cpp
+++ b/Libraries/pbxbuild/Sources/Tool/SymlinkResolver.cpp
@@ -38,6 +38,7 @@ resolve(
     invocation.outputs() = { FSUtil::ResolveRelativePath(symlinkPath, workingDirectory) };
     invocation.logMessage() = logMessage;
     invocation.createsProductStructure() = productStructure;
+    invocation.priority() = toolContext->currentPhaseInvocationPriority();
     toolContext->invocations().push_back(invocation);
 }
 

--- a/Libraries/pbxbuild/Sources/Tool/ToolResolver.cpp
+++ b/Libraries/pbxbuild/Sources/Tool/ToolResolver.cpp
@@ -59,6 +59,7 @@ resolve(
     invocation.outputs() = toolEnvironment.outputs(toolContext->workingDirectory());
     invocation.dependencyInfo() = dependencyInfo;
     invocation.logMessage() = resolvedLogMessage;
+    invocation.priority() = toolContext->currentPhaseInvocationPriority();
     toolContext->invocations().push_back(invocation);
 }
 
@@ -83,6 +84,7 @@ resolve(
     invocation.inputs() = toolEnvironment.inputs(toolContext->workingDirectory());
     invocation.outputs() = toolEnvironment.outputs(toolContext->workingDirectory());
     invocation.logMessage() = resolvedLogMessage;
+    invocation.priority() = toolContext->currentPhaseInvocationPriority();
     toolContext->invocations().push_back(invocation);
 }
 

--- a/Libraries/pbxbuild/Sources/Tool/TouchResolver.cpp
+++ b/Libraries/pbxbuild/Sources/Tool/TouchResolver.cpp
@@ -48,6 +48,7 @@ resolve(
     invocation.outputs() = { output };
     invocation.inputDependencies() = inputDependencies;
     invocation.logMessage() = logMessage;
+    invocation.priority() = toolContext->currentPhaseInvocationPriority();
     toolContext->invocations().push_back(invocation);
 }
 


### PR DESCRIPTION
Currently, we are munging all invocations within a target and don't setup execution order based on phase ordering.
This creates problem when build phases are set up in a way to executed in specific ordering.

Prioritize all invocations with respect to their phase ordering, so that executions are done in order their phases are defined.