### PR TITLE
Add `CODE_OF_CONDUCT.md`

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Code of Conduct
+
+This project adheres to the [Open Code of Conduct](http://todogroup.org/opencodeofconduct/#xcbuild/opensource@fb.com). By participating, you are expected to honor this code.


### PR DESCRIPTION
**what is the change?:**
Adding a document linking to the Facebook Open Source Code of Conduct,
for visibility and to meet Github community standards.

**why make this change?:**
It's important that contributors can find the Code of Conduct for a
project.

xcbuild already links to a Code of Conduct in the Contributing guide, which is
great! :)

Exposing the COC via a separate markdown file is a standard being
promoted by Github via the Community Profile in order to meet their Open
Source Guide's recommended community standards.

As you can see, adding this file will complete [xcbuild's Community Profile](https://github.com/facebook/xcbuild/community)
checklist and increase the visibility of our COC.

**test plan:**
Viewing it on my branch -
<img width="1008" alt="screen shot 2017-12-07 at 4 20 32 pm" src="https://user-images.githubusercontent.com/1114467/33745338-2b96a8a6-db6b-11e7-9e68-b0a31ae07360.png">

**issue:**
internal task t23481323