### PR TITLE
libcar: silence a -Wsign-compare warning

### DIFF
--- a/Libraries/libcar/Sources/AttributeList.cpp
+++ b/Libraries/libcar/Sources/AttributeList.cpp
@@ -44,10 +44,12 @@ void AttributeList::
 dump() const
 {
     for (auto const &entry : _values) {
+        constexpr auto num_identifiers =
+            sizeof(car_attribute_identifier_names) / sizeof(*car_attribute_identifier_names);
         enum car_attribute_identifier identifier = entry.first;
         uint16_t value = entry.second;
 
-        if (identifier < sizeof(car_attribute_identifier_names) / sizeof(*car_attribute_identifier_names)) {
+        if (static_cast<decltype(num_identifiers)>(identifier) < num_identifiers) {
             printf("[%02d] %-24s = %-6d | %-4x\n", identifier, car_attribute_identifier_names[identifier] ? car_attribute_identifier_names[identifier] : "(unknown)", value, value);
         } else {
             printf("[%02d] %-24s = %-6d | %-4x\n", identifier, "(unknown)", value, value);


### PR DESCRIPTION
When building libcar for Windows, the array size calculation would be of type
`unsigned long long` (aka `size_t`).  However, `identifier` is of type
`enum car_attribute_identifier` (aka `int`).  This results in a warning due to
the sign mismatch.  Perform an explicit cast to the size type for the
comparision to silence the warning.

Take the opportunity to move the constant expression of the array length into a
variable for ease of readability.