### PR TITLE
print usage information for wrong arguments

### DIFF
--- a/Libraries/xcdriver/Sources/Driver.cpp
+++ b/Libraries/xcdriver/Sources/Driver.cpp
@@ -46,7 +46,8 @@ Run(process::User const *user, process::Context const *processContext, process::
     Options options;
     std::pair<bool, std::string> result = libutil::Options::Parse<Options>(&options, processContext->commandLineArguments());
     if (!result.first) {
-        fprintf(stderr, "error: %s\n", result.second.c_str());
+        fprintf(stderr, "error: %s\n\n", result.second.c_str());
+        UsageAction::Run(processContext);
         return 1;
     }
 

--- a/Libraries/xcdriver/Sources/Usage.cpp
+++ b/Libraries/xcdriver/Sources/Usage.cpp
@@ -77,6 +77,8 @@ Text(std::string const &name) {
         "-localizationPath <path> "
         "-project <projectname>" << std::endl;
 
+    result << "       " << name << " -help" << std::endl;
+
     result << std::endl;
 
     return result.str();


### PR DESCRIPTION
this PR makes `xcbuild` dump the usage-information if it encounters an error while parsing the cmdline args (mostly this will be because the user passed unknown flags)