### PR TITLE
undefine major/minor macros to prevent build failures with newer glibc

### DIFF
--- a/Libraries/xcassets/Headers/xcassets/Slot/SystemVersion.h
+++ b/Libraries/xcassets/Headers/xcassets/Slot/SystemVersion.h
@@ -13,6 +13,13 @@
 #include <ext/optional>
 #include <string>
 
+#ifdef major
+# undef major
+#endif
+#ifdef minor
+# undef minor
+#endif
+
 namespace xcassets {
 namespace Slot {
 

--- a/Libraries/xcassets/Headers/xcassets/Slot/SystemVersion.h
+++ b/Libraries/xcassets/Headers/xcassets/Slot/SystemVersion.h
@@ -13,6 +13,10 @@
 #include <ext/optional>
 #include <string>
 
+/*
+ * for legacy reasons, the GNU C Library might define major & minor,
+ * breaking the compilation unless we undefine them.
+ */
 #ifdef major
 # undef major
 #endif


### PR DESCRIPTION
while fixing #274, I noticed that xcbuild fails to build from source, at least on an up-to-date Debian/sid system, with the following error

~~~
../Libraries/xcassets/Headers/xcassets/Slot/SystemVersion.h:35:13: error: In the GNU C Library, "major" is defined
 by <sys/sysmacros.h>. For historical compatibility, it is
 currently defined by <sys/types.h> as well, but we plan to
 remove this soon. To use "major", include <sys/sysmacros.h>
 directly. If you did not intend to use a system-defined macro
 "major", you should undefine it after including <sys/types.h>. [-Werror]
     int major() const
             ^~~~~~~~~                                                                                                                                                                                                                                                                                                                                                               
In file included from ../Libraries/xcassets/Headers/xcassets/Asset/LaunchImage.h:19:0,
                 from ../Libraries/acdriver/Headers/acdriver/Compile/LaunchImage.h:14,
                 from ../Libraries/acdriver/Sources/Compile/Asset.cpp:23:
../Libraries/xcassets/Headers/xcassets/Slot/SystemVersion.h:41:13: error: In the GNU C Library, "minor" is defined
 by <sys/sysmacros.h>. For historical compatibility, it is
 currently defined by <sys/types.h> as well, but we plan to
 remove this soon. To use "minor", include <sys/sysmacros.h>
 directly. If you did not intend to use a system-defined macro
 "minor", you should undefine it after including <sys/types.h>. [-Werror]
     int minor() const
~~~

This PR does what the compiler-error suggests: undefine the "minor" and "major" macros (if they are defined) before using these names, fixing the build failure.