### PR TITLE
Add --allow-non-standard-behavior and --allow-image-type webp to actool

### DIFF
--- a/Libraries/acdriver/CMakeLists.txt
+++ b/Libraries/acdriver/CMakeLists.txt
@@ -10,6 +10,7 @@
 add_library(acdriver
             Sources/Options.cpp
             Sources/Driver.cpp
+            Sources/NonStandard.cpp
             Sources/Output.cpp
             Sources/Result.cpp
             Sources/VersionAction.cpp

--- a/Libraries/acdriver/Headers/acdriver/Compile/Output.h
+++ b/Libraries/acdriver/Headers/acdriver/Compile/Output.h
@@ -10,6 +10,7 @@
 #ifndef __acdriver_Compile_Output_h
 #define __acdriver_Compile_Output_h
 
+#include <acdriver/NonStandard.h>
 #include <plist/Dictionary.h>
 #include <car/Writer.h>
 
@@ -48,6 +49,7 @@ private:
 private:
     ext::optional<std::string>         _appIcon;
     ext::optional<std::string>         _launchImage;
+    NonStandard::ImageTypeSet          _allowedNonStandardImageTypes;
 
 private:
     ext::optional<car::Writer>         _car;
@@ -63,7 +65,8 @@ public:
         std::string const &root,
         Format format,
         ext::optional<std::string> const &appIcon,
-        ext::optional<std::string> const &launchImage);
+        ext::optional<std::string> const &launchImage,
+        NonStandard::ImageTypeSet const &allowedNonStandardImageTypes = NonStandard::ImageTypeSet());
 
 public:
     /*
@@ -90,6 +93,13 @@ public:
      */
     ext::optional<std::string> const &launchImage()
     { return _launchImage; }
+
+    /*
+     * List of non-standard image formats that are allowed into an image set
+     * when non-standard behavior are enabled.
+     */
+    NonStandard::ImageTypeSet const &allowedNonStandardImageTypes() const
+    { return _allowedNonStandardImageTypes; }
 
 public:
     /*

--- a/Libraries/acdriver/Headers/acdriver/NonStandard.h
+++ b/Libraries/acdriver/Headers/acdriver/NonStandard.h
@@ -1,0 +1,84 @@
+/**
+ Copyright (c) 2015-present, Facebook, Inc.
+ All rights reserved.
+
+ This source code is licensed under the BSD-style license found in the
+ LICENSE file in the root directory of this source tree. An additional grant
+ of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#ifndef __acdriver_NonStandard_h
+#define __acdriver_NonStandard_h
+
+#include <acdriver/Result.h>
+#include <car/Rendition.h>
+
+#include <algorithm>
+#include <ext/optional>
+#include <string>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+namespace acdriver {
+
+/*
+ * Contains non-standard related logic
+ */
+class NonStandard {
+public:
+    /*
+     *  Extra image types (besides PNG and JPEG) to include in ImageSet
+     */
+    enum class ImageType {
+        WEBP,
+    };
+
+    class ImageTypeHash
+    {
+    public:
+        std::size_t operator()(ImageType t) const
+        {
+            return static_cast<std::size_t>(t);
+        }
+    };
+
+    typedef std::unordered_set<ImageType, ImageTypeHash> ImageTypeSet;
+
+public:
+    /*
+     * Extension options for actool
+     */
+    class ActoolOptions {
+    private:
+        ext::optional<bool>        _allowNonStandardBehavior;
+        ImageTypeSet               _allowImageTypes;
+
+    public:
+        bool allowNonStandardBehavior() const
+        { return _allowNonStandardBehavior.value_or(false); }
+        ImageTypeSet allowImageTypes() const
+        { return _allowImageTypes; }
+
+    public:
+        ext::optional<std::pair<bool, std::string>> parseArgument(std::vector<std::string> const &args, std::vector<std::string>::const_iterator *it);
+
+    public:
+        bool isValid(acdriver::Result *result) const;
+    };
+
+public:
+    /*
+     * Translates a filename extension of an acceptable type to ImageType enum.
+     */
+    static ext::optional<ImageType> ImageTypeFromFileExtension(std::string const &extension);
+
+    /*
+     * Translates an ImageType enum to the proper data format used in car::Rendition
+     */
+    static car::Rendition::Data::Format ImageTypeToDataFormat(ImageType type);
+};
+
+}
+
+#endif // !__acdriver_NonStandard_h

--- a/Libraries/acdriver/Headers/acdriver/Options.h
+++ b/Libraries/acdriver/Headers/acdriver/Options.h
@@ -10,6 +10,8 @@
 #ifndef __acdriver_Options_h
 #define __acdriver_Options_h
 
+#include <acdriver/NonStandard.h>
+#include <acdriver/Result.h>
 #include <libutil/Options.h>
 
 #include <string>
@@ -72,6 +74,10 @@ private:
     ext::optional<std::string> _filterForDeviceModel;
     ext::optional<std::string> _filterForDeviceOsVersion;
     ext::optional<std::string> _assetPackOutputSpecifications;
+
+private:
+    // Options not compatible with Apple's actool
+    NonStandard::ActoolOptions  _nonStandardOptions;
 
 public:
     Options();
@@ -151,6 +157,15 @@ public:
     { return _filterForDeviceOsVersion; }
     ext::optional<std::string> const &assetPackOutputSpecifications() const
     { return _assetPackOutputSpecifications; }
+
+public:
+    NonStandard::ActoolOptions const &nonStandardOptions() const
+    { return _nonStandardOptions; }
+
+public:
+
+    bool
+    isValid(Result *result) const;
 
 private:
     friend class libutil::Options;

--- a/Libraries/acdriver/Sources/Compile/ImageSet.cpp
+++ b/Libraries/acdriver/Sources/Compile/ImageSet.cpp
@@ -151,11 +151,29 @@ CompileAsset(
 
         format = car::Rendition::Data::Format::JPEG;
     } else {
-        result->normal(
-            Result::Severity::Error,
-            "unknown file type",
-            filename);
-        return false;
+        ext::optional<NonStandard::ImageType> type = NonStandard::ImageTypeFromFileExtension(FSUtil::GetFileExtension(filename));
+        if (!type) {
+            result->normal(
+                Result::Severity::Error,
+                "unknown file type",
+                filename);
+            return false;
+        }
+        if (!compileOutput->allowedNonStandardImageTypes().count(*type)) {
+            result->normal(
+                Result::Severity::Error,
+                "forbidden file type",
+                filename);
+            return false;
+        }
+        if (!filesystem->read(&pixels, filename)) {
+            result->normal(
+                Result::Severity::Error,
+                "unable to read image file",
+                filename);
+            return false;
+        }
+        format = NonStandard::ImageTypeToDataFormat(*type);
     }
 
     bool createFacet = false;

--- a/Libraries/acdriver/Sources/Compile/Output.cpp
+++ b/Libraries/acdriver/Sources/Compile/Output.cpp
@@ -29,12 +29,14 @@ Output(
     std::string const &root,
     Format format,
     ext::optional<std::string> const &appIcon,
-    ext::optional<std::string> const &launchImage) :
-    _root          (root),
-    _format        (format),
-    _appIcon       (appIcon),
-    _launchImage   (launchImage),
-    _additionalInfo(plist::Dictionary::New())
+    ext::optional<std::string> const &launchImage,
+    NonStandard::ImageTypeSet const &allowedNonStandardImageTypes) :
+    _root                        (root),
+    _format                      (format),
+    _appIcon                     (appIcon),
+    _launchImage                 (launchImage),
+    _allowedNonStandardImageTypes (allowedNonStandardImageTypes),
+    _additionalInfo              (plist::Dictionary::New())
 {
 }
 
@@ -44,4 +46,3 @@ AssetReference(xcassets::Asset::Asset const *asset)
     // TODO: include [] for each key
     return asset->path();
 }
-

--- a/Libraries/acdriver/Sources/CompileAction.cpp
+++ b/Libraries/acdriver/Sources/CompileAction.cpp
@@ -245,6 +245,10 @@ run(Filesystem *filesystem, Options const &options, Output *output, Result *resu
     // TODO: support all options
     WarnUnsupportedOptions(options, result);
 
+    if (!options.isValid(result)) {
+       return;
+    }
+
     /*
      * Determine format to output compiled assets.
      */
@@ -261,7 +265,8 @@ run(Filesystem *filesystem, Options const &options, Output *output, Result *resu
         *options.compile(),
         *outputFormat,
         options.appIcon(),
-        options.launchImage());
+        options.launchImage(),
+        options.nonStandardOptions().allowImageTypes());
 
     /*
      * If necessary, create output archive to write into.

--- a/Libraries/acdriver/Sources/NonStandard.cpp
+++ b/Libraries/acdriver/Sources/NonStandard.cpp
@@ -1,0 +1,74 @@
+/**
+ Copyright (c) 2015-present, Facebook, Inc.
+ All rights reserved.
+
+ This source code is licensed under the BSD-style license found in the
+ LICENSE file in the root directory of this source tree. An additional grant
+ of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#include <acdriver/NonStandard.h>
+#include <libutil/Options.h>
+
+using acdriver::NonStandard;
+
+static std::pair<bool, std::string>
+InsertNextImageType(NonStandard::ImageTypeSet &imageTypeSet, std::vector<std::string> const &args, std::vector<std::string>::const_iterator *it)
+{
+    ext::optional<std::string> value;
+    auto ret = libutil::Options::Next<std::string>(&value, args, it);
+    if (!ret.first) {
+        return ret;
+    }
+    ext::optional<NonStandard::ImageType> type = NonStandard::ImageTypeFromFileExtension(*value);
+    if (!type) {
+        return std::make_pair(false, "unknown image type " + *value);
+    }
+    imageTypeSet.insert(*type);
+    return std::make_pair(true, std::string());
+}
+
+ext::optional<std::pair<bool, std::string>> NonStandard::ActoolOptions::
+parseArgument(std::vector<std::string> const &args, std::vector<std::string>::const_iterator *it)
+{
+    std::string const &arg = **it;
+
+    if (arg == "--allow-non-standard-behavior") {
+        return libutil::Options::Current<bool>(&_allowNonStandardBehavior, arg);
+    } else if (arg == "--allow-image-type") {
+        return InsertNextImageType(_allowImageTypes, args, it);
+    } else {
+        return ext::nullopt;
+    }
+}
+
+bool NonStandard::ActoolOptions::
+isValid(acdriver::Result *result) const
+{
+    if (!allowNonStandardBehavior() && !allowImageTypes().empty()) {
+        result->normal(Result::Severity::Error, "--allow-image-type requires --allow-non-standard-behavior");
+        return false;
+    }
+    return true;
+}
+
+car::Rendition::Data::Format NonStandard::
+ImageTypeToDataFormat(ImageType type) {
+    switch (type) {
+        case NonStandard::ImageType::WEBP:
+            return car::Rendition::Data::Format::NON_STANDARD_WEBP;
+    }
+
+    abort();
+}
+
+ext::optional<NonStandard::ImageType> NonStandard::
+ImageTypeFromFileExtension(std::string const &extension)
+{
+    std::string lowerExtension;
+    std::transform(extension.begin(), extension.end(), std::back_inserter(lowerExtension), ::tolower);
+    if (lowerExtension == "webp") {
+        return NonStandard::ImageType::WEBP;
+    }
+    return ext::nullopt;
+}

--- a/Libraries/acdriver/Sources/Options.cpp
+++ b/Libraries/acdriver/Sources/Options.cpp
@@ -87,7 +87,20 @@ parseArgument(std::vector<std::string> const &args, std::vector<std::string>::co
     } else if (!arg.empty() && arg[0] != '-') {
         return libutil::Options::AppendCurrent<std::string>(&_inputs, arg);
     } else {
+        ext::optional<std::pair<bool, std::string>> nonStandardResult = _nonStandardOptions.parseArgument(args, it);
+        if (nonStandardResult) {
+            return *nonStandardResult;
+        }
         return std::make_pair(false, "unknown argument " + arg);
     }
 }
 
+
+bool Options::
+isValid(Result *result) const
+{
+    if (!nonStandardOptions().isValid(result)) {
+        return false;
+    }
+    return true;
+}

--- a/Libraries/libcar/Headers/car/Rendition.h
+++ b/Libraries/libcar/Headers/car/Rendition.h
@@ -44,12 +44,21 @@ public:
              * Raw data.
              */
             Data,
+            /*
+             * Non-standard formats
+             */
+            NON_STANDARD_WEBP,
         };
 
         /*
          * The size of a pixel in the format.
          */
         static size_t FormatSize(Format format);
+
+        /*
+         * If the format is saved as raw data, that requires additional headers
+         */
+        static bool FormatSavedAsRawData(Format format);
 
     private:
         std::vector<uint8_t> _data;

--- a/Libraries/libcar/Headers/car/car_format.h
+++ b/Libraries/libcar/Headers/car/car_format.h
@@ -293,6 +293,7 @@ enum car_rendition_value_pixel_format {
     car_rendition_value_pixel_format_pdf = 'PDF ', // pdf document
     car_rendition_value_pixel_format_raw_data = 'DATA', // raw data
     car_rendition_value_pixel_format_jpeg = 'JPEG', // jpeg image
+    car_rendition_value_pixel_format_non_standard_webp = 'WEBP', // webp image
 };
 
 enum car_rendition_value_layout {


### PR DESCRIPTION
Adding the capability to pack WEBP images into compiled assets catalog.
Since this is not standard behavior, I'm adding it under `--allows-image-types webp`.
This way (`--allows-image-types`) also makes it easier to add future new extension types.
Since this is not a feature supported by Apple's Xcode.actool, I'm also adding `--allow-extensions` as well, that makes it explicit it's incompatible behavior.