### PR TITLE
Allow symlinked paths when passing an SDK to xcrun

### DIFF
--- a/Libraries/acdriver/Tests/test_AppIconSet.cpp
+++ b/Libraries/acdriver/Tests/test_AppIconSet.cpp
@@ -136,4 +136,3 @@ TEST(AppIconSet, Compile)
     VerifyIcons(info, "CFBundleIcons", { "AppIcon29x29", "AppIcon60x60" });
     VerifyIcons(info, "CFBundleIcons~ipad", { "AppIcon76x76" });
 }
-

--- a/Libraries/libutil/Headers/libutil/DefaultFilesystem.h
+++ b/Libraries/libutil/Headers/libutil/DefaultFilesystem.h
@@ -36,6 +36,7 @@ public:
 public:
     virtual ext::optional<Permissions> readSymbolicLinkPermissions(std::string const &path) const;
     virtual bool writeSymbolicLinkPermissions(std::string const &path, Permissions::Operation operation, Permissions permissions);
+    virtual ext::optional<std::string> readSymbolicLinkCanonical(std::string const &path, bool *directory = nullptr) const;
     virtual ext::optional<std::string> readSymbolicLink(std::string const &path, bool *directory = nullptr) const;
     virtual bool writeSymbolicLink(std::string const &target, std::string const &path, bool directory);
     virtual bool copySymbolicLink(std::string const &from, std::string const &to);

--- a/Libraries/libutil/Headers/libutil/FSUtil.h
+++ b/Libraries/libutil/Headers/libutil/FSUtil.h
@@ -37,6 +37,7 @@ public:
 public:
     static std::string ResolveRelativePath(std::string const &path, std::string const &workingDirectory);
     static std::string NormalizePath(std::string const &path);
+    static std::vector<std::string> NormalizePathComponents(std::string const &path);
 
 public:
     static std::string FindFile(std::string const &name, std::vector<std::string> const &paths);

--- a/Libraries/libutil/Headers/libutil/Filesystem.h
+++ b/Libraries/libutil/Headers/libutil/Filesystem.h
@@ -116,6 +116,12 @@ public:
 
     /*
      * Read the destination of the symbolic link, relative to its containing directory.
+     * Fully resolves the symlink path (if it is one) and returns a valid path if no error.
+     */
+    virtual ext::optional<std::string> readSymbolicLinkCanonical(std::string const &path, bool *directory = nullptr) const = 0;
+
+    /*
+     * Read the destination of the symbolic link, relative to its containing directory.
      */
     virtual ext::optional<std::string> readSymbolicLink(std::string const &path, bool *directory = nullptr) const = 0;
 

--- a/Libraries/libutil/Headers/libutil/MemoryFilesystem.h
+++ b/Libraries/libutil/Headers/libutil/MemoryFilesystem.h
@@ -91,6 +91,7 @@ public:
 public:
     virtual ext::optional<Permissions> readSymbolicLinkPermissions(std::string const &path) const;
     virtual bool writeSymbolicLinkPermissions(std::string const &path, Permissions::Operation operation, Permissions permissions);
+    virtual ext::optional<std::string> readSymbolicLinkCanonical(std::string const &path, bool *directory = nullptr) const;
     virtual ext::optional<std::string> readSymbolicLink(std::string const &path, bool *directory = nullptr) const;
     virtual bool writeSymbolicLink(std::string const &target, std::string const &path, bool directory);
     virtual bool copySymbolicLink(std::string const &from, std::string const &to);

--- a/Libraries/libutil/Headers/libutil/Relative.h
+++ b/Libraries/libutil/Headers/libutil/Relative.h
@@ -15,6 +15,7 @@
 
 #include <string>
 #include <ext/optional>
+#include <vector>
 
 namespace libutil {
 namespace Path {
@@ -51,6 +52,12 @@ public:
      * The normalized path string.
      */
     std::string normalized() const;
+
+    /*
+     * The normalized path string, split according to the components
+     * that comprise it.
+     */
+    std::vector<std::string> normalizedComponents() const;
 
 public:
     /*

--- a/Libraries/libutil/Sources/FSUtil.cpp
+++ b/Libraries/libutil/Sources/FSUtil.cpp
@@ -98,3 +98,9 @@ NormalizePath(std::string const &path)
 {
     return Path::Relative(path).normalized();
 }
+
+std::vector<std::string> FSUtil::
+NormalizePathComponents(std::string const &path)
+{
+    return Path::Relative(path).normalizedComponents();
+}

--- a/Libraries/libutil/Sources/MemoryFilesystem.cpp
+++ b/Libraries/libutil/Sources/MemoryFilesystem.cpp
@@ -362,6 +362,12 @@ removeFile(std::string const &path)
 }
 
 ext::optional<std::string> MemoryFilesystem::
+readSymbolicLinkCanonical(std::string const &path, bool *directory) const
+{
+    return ext::nullopt;
+}
+
+ext::optional<std::string> MemoryFilesystem::
 readSymbolicLink(std::string const &path, bool *directory) const
 {
     return ext::nullopt;
@@ -475,4 +481,3 @@ resolvePath(std::string const &path) const
         return std::string();
     }
 }
-

--- a/Libraries/libutil/Tests/test_FSUtil.cpp
+++ b/Libraries/libutil/Tests/test_FSUtil.cpp
@@ -15,6 +15,15 @@ using libutil::FSUtil;
 // TODO: remove these tests once FSUtil is unused
 #if !_WIN32
 
+template <typename T>
+void EXPECT_VECTOR_EQ(std::vector<T> const &x, std::vector<T> const &y) {
+    ASSERT_EQ(x.size(), y.size()) << "Vectors x and y are of unequal length";
+
+    for (int i = 0; i < x.size(); ++i) {
+        EXPECT_EQ(x[i], y[i]) << "Vectors x and y differ at index " << i;
+    }
+}
+
 TEST(FSUtil, GetDirectoryName)
 {
     EXPECT_EQ("", FSUtil::GetDirectoryName(""));
@@ -104,6 +113,30 @@ TEST(FSUtil, IsFileExtension)
 
     EXPECT_FALSE(FSUtil::IsFileExtension("/a/b/c.sub.ext", ""));
     EXPECT_TRUE(FSUtil::IsFileExtension("/a/b/c.sub.ext", "ext"));
+}
+
+TEST(FSUtil, Normalize)
+{
+    EXPECT_EQ("/a/b", FSUtil::NormalizePath("/a/b"));
+    EXPECT_EQ("/a/b", FSUtil::NormalizePath("/a/./b"));
+    EXPECT_EQ("/b", FSUtil::NormalizePath("/a/../b"));
+    EXPECT_EQ("a/b", FSUtil::NormalizePath("a/./b"));
+    EXPECT_EQ("..", FSUtil::NormalizePath("a/../.."));
+    EXPECT_EQ("/", FSUtil::NormalizePath("/a/../.."));
+    EXPECT_EQ("../../..", FSUtil::NormalizePath("a/../../../.."));
+    EXPECT_EQ("/", FSUtil::NormalizePath("////"));
+}
+
+TEST(FSUtil, NormalizeComponents)
+{
+    EXPECT_VECTOR_EQ({ "/", "a", "b" }, FSUtil::NormalizePathComponents("/a/b"));
+    EXPECT_VECTOR_EQ({ "a", "b" }, FSUtil::NormalizePathComponents("a/b"));
+    EXPECT_VECTOR_EQ({ "/", "a", "b" }, FSUtil::NormalizePathComponents("/a/./b"));
+    EXPECT_VECTOR_EQ({ "/", "b" }, FSUtil::NormalizePathComponents("/a/../b"));
+    EXPECT_VECTOR_EQ({ ".." }, FSUtil::NormalizePathComponents("a/../.."));
+    EXPECT_VECTOR_EQ({ "/" }, FSUtil::NormalizePathComponents("/a/../.."));
+    EXPECT_VECTOR_EQ({ "..", "..", ".." }, FSUtil::NormalizePathComponents("a/../../../.."));
+    EXPECT_VECTOR_EQ({ "/" }, FSUtil::NormalizePathComponents("////"));
 }
 
 #endif

--- a/Libraries/pbxbuild/Sources/Target/Environment.cpp
+++ b/Libraries/pbxbuild/Sources/Target/Environment.cpp
@@ -15,7 +15,6 @@
 #include <pbxsetting/Type.h>
 #include <pbxsetting/XC/Config.h>
 #include <libutil/FSUtil.h>
-#include <libutil/Filesystem.h>
 
 #include <algorithm>
 #include <iterator>
@@ -24,7 +23,6 @@
 namespace Build = pbxbuild::Build;
 namespace Target = pbxbuild::Target;
 using pbxbuild::WorkspaceContext;
-using libutil::Filesystem;
 using libutil::FSUtil;
 
 Target::Environment::
@@ -366,7 +364,7 @@ Create(Build::Environment const &buildEnvironment, Build::Context const &buildCo
          * All settings added; determine target SDK.
          */
         std::string sdkroot = determinationEnvironment.resolve("SDKROOT");
-        sdk = buildEnvironment.sdkManager()->findTarget(sdkroot);
+        sdk = buildEnvironment.sdkManager()->findTarget(nullptr, sdkroot);
         if (sdk == nullptr) {
             fprintf(stderr, "error: unable to find sdkroot %s\n", sdkroot.c_str());
             return ext::nullopt;
@@ -466,7 +464,7 @@ Create(Build::Environment const &buildEnvironment, Build::Context const &buildCo
     std::vector<xcsdk::SDK::Toolchain::shared_ptr> toolchains;
     std::vector<std::string> effectiveToolchainPaths;
     for (std::string const &toolchainName : pbxsetting::Type::ParseList(environment.resolve("TOOLCHAINS"))) {
-        if (xcsdk::SDK::Toolchain::shared_ptr toolchain = buildEnvironment.sdkManager()->findToolchain(toolchainName)) {
+        if (xcsdk::SDK::Toolchain::shared_ptr toolchain = buildEnvironment.sdkManager()->findToolchain(nullptr, toolchainName)) {
             // TODO: Apply toolchain override build settings.
             toolchains.push_back(toolchain);
             effectiveToolchainPaths.push_back(toolchain->path());

--- a/Libraries/process/Headers/process/Context.h
+++ b/Libraries/process/Headers/process/Context.h
@@ -57,6 +57,12 @@ public:
      * The default environment search paths.
      */
     std::vector<std::string> executableSearchPaths() const;
+
+public:
+    /*
+     * The path expanded with resolved shell variables and user directory.
+     */
+    virtual ext::optional<std::string> const shellExpand(std::string const &s) const = 0;
 };
 
 }

--- a/Libraries/process/Headers/process/DefaultContext.h
+++ b/Libraries/process/Headers/process/DefaultContext.h
@@ -31,6 +31,9 @@ public:
     virtual std::vector<std::string> const &commandLineArguments() const;
     virtual std::unordered_map<std::string, std::string> const &environmentVariables() const;
     virtual ext::optional<std::string> environmentVariable(std::string const &variable) const;
+
+public:
+    virtual ext::optional<std::string> const shellExpand(std::string const &s) const;
 };
 
 }

--- a/Libraries/process/Headers/process/MemoryContext.h
+++ b/Libraries/process/Headers/process/MemoryContext.h
@@ -58,6 +58,9 @@ public:
     { return _environmentVariables; }
 
     virtual ext::optional<std::string> environmentVariable(std::string const &variable) const;
+
+public:
+    virtual ext::optional<std::string> const shellExpand(std::string const &s) const;
 };
 
 }

--- a/Libraries/process/Sources/MemoryContext.cpp
+++ b/Libraries/process/Sources/MemoryContext.cpp
@@ -51,3 +51,8 @@ environmentVariable(std::string const &variable) const
     }
 }
 
+ext::optional<std::string> const MemoryContext::
+shellExpand(std::string const &s) const
+{
+    return s;
+}

--- a/Libraries/xcdriver/Sources/FindAction.cpp
+++ b/Libraries/xcdriver/Sources/FindAction.cpp
@@ -48,7 +48,7 @@ Run(process::User const *user, process::Context const *processContext, Filesyste
 
     std::string sdk = options.sdk().value_or("macosx");
 
-    xcsdk::SDK::Target::shared_ptr target = manager->findTarget(sdk);
+    xcsdk::SDK::Target::shared_ptr target = manager->findTarget(filesystem, sdk);
     if (target == nullptr) {
         fprintf(stderr, "error: cannot find sdk '%s'\n", sdk.c_str());
         return 1;

--- a/Libraries/xcdriver/Sources/VersionAction.cpp
+++ b/Libraries/xcdriver/Sources/VersionAction.cpp
@@ -56,7 +56,7 @@ Run(process::User const *user, process::Context const *processContext, Filesyste
             return 1;
         }
 
-        xcsdk::SDK::Target::shared_ptr target = manager->findTarget(*options.sdk());
+        xcsdk::SDK::Target::shared_ptr target = manager->findTarget(filesystem, *options.sdk());
         if (target == nullptr) {
             fprintf(stderr, "error: cannot find sdk '%s'\n", options.sdk()->c_str());
             return 1;

--- a/Libraries/xcsdk/Headers/xcsdk/SDK/Manager.h
+++ b/Libraries/xcsdk/Headers/xcsdk/SDK/Manager.h
@@ -13,6 +13,7 @@
 #include <xcsdk/SDK/Platform.h>
 #include <xcsdk/SDK/Toolchain.h>
 #include <xcsdk/SDK/Target.h>
+#include <libutil/Filesystem.h>
 
 #include <memory>
 #include <string>
@@ -61,14 +62,18 @@ public:
     /*
      * Find an SDK by name. This does a fuzzy search, so the "name" could
      * be an SDK name or path, or even the name of a platform.
+     * The provided filesystem will attempt to resolve the name if the name is
+     * a symlinked path.
      */
-    Target::shared_ptr findTarget(std::string const &name) const;
+    Target::shared_ptr findTarget(libutil::Filesystem const *filesystem, std::string const &name) const;
 
     /*
      * Find a toolchain by name. This does a fuzzy search; the "name" could
      * be a name, path, or identifier for the toolchain.
+     * The provided filesystem will attempt to resolve the name if the name is
+     * a symlinked path.
      */
-    Toolchain::shared_ptr findToolchain(std::string const &name) const;
+    Toolchain::shared_ptr findToolchain(libutil::Filesystem const *filesystem, std::string const &name) const;
 
 public:
     /*

--- a/Libraries/xcsdk/Sources/SDK/Target.cpp
+++ b/Libraries/xcsdk/Sources/SDK/Target.cpp
@@ -95,9 +95,9 @@ parse(plist::Dictionary const *dict)
         if (std::shared_ptr<Manager> manager = _manager.lock()) {
             for (size_t n = 0; n < Ts ->count(); n++) {
                 if (auto T = Ts ->value <plist::String> (n)) {
-                    if (auto toolchain = manager->findToolchain(T->value())) {
+                    if (auto toolchain = manager->findToolchain(nullptr, T->value())) {
                         _toolchains.push_back(toolchain);
-                    } else if (auto defaultToolchain = manager->findToolchain(Toolchain::DefaultIdentifier())) {
+                    } else if (auto defaultToolchain = manager->findToolchain(nullptr, Toolchain::DefaultIdentifier())) {
                         _toolchains.push_back(defaultToolchain);
                     }
                 }
@@ -105,7 +105,7 @@ parse(plist::Dictionary const *dict)
         }
     } else {
         if (std::shared_ptr<Manager> manager = _manager.lock()) {
-            if (auto defaultToolchain = manager->findToolchain(Toolchain::DefaultIdentifier())) {
+            if (auto defaultToolchain = manager->findToolchain(nullptr, Toolchain::DefaultIdentifier())) {
                 _toolchains.push_back(defaultToolchain);
             }
         }

--- a/Libraries/xcsdk/Tools/xcrun.cpp
+++ b/Libraries/xcsdk/Tools/xcrun.cpp
@@ -302,13 +302,13 @@ static int Run(Filesystem *filesystem, process::User const *user, process::Conte
     xcsdk::SDK::Target::shared_ptr target = nullptr;
     if (!toolchainSpecified) {
         if (SDK) {
-            target = manager->findTarget(*SDK);
+            target = manager->findTarget(filesystem, *SDK);
             if (target == nullptr) {
                 printf("error: unable to find sdk: '%s'\n", SDK->c_str());
                 return -1;
             }
         } else {
-            target = manager->findTarget(defaultSDK);
+            target = manager->findTarget(filesystem, defaultSDK);
             /* nullptr target is not an error (except later on if SDK information is requested) */
             if (showSDKValue && target == nullptr) {
                 printf("error: unable os find default sdk: '%s'\n", defaultSDK.c_str());
@@ -373,7 +373,7 @@ static int Run(Filesystem *filesystem, process::User const *user, process::Conte
             /* If the custom toolchain exists, use it instead. */
             std::vector<std::string> toolchainTokens = pbxsetting::Type::ParseList(*toolchainsInput);
             for (std::string const &toolchainToken : toolchainTokens) {
-                if (auto TC = manager->findToolchain(toolchainToken)) {
+                if (auto TC = manager->findToolchain(filesystem, toolchainToken)) {
                     toolchains.push_back(TC);
                 }
             }


### PR DESCRIPTION
Several changes here:

- Filesystem::readSymbolicLink() now behaves like "readlink -f", so links will be
  thoroughly resolved.
- The SDK Manager will now try to resolve toolchains and SDKs passed its
  way using a FS object.  Most locations have been stubbed with a
  nullptr for the FS since those are internally-provided toolchain names
  / paths, but some locations that can take in user-provided input are
  different.
- I added some functionality to convert a path into a vector of
  components; I use this to iterate though a given path and invoke
  "readlink()" per step.