### PR TITLE
stringop-truncation and address-of-packed-member

### DIFF
--- a/Libraries/libbom/Sources/bom.c
+++ b/Libraries/libbom/Sources/bom.c
@@ -57,7 +57,7 @@ bom_alloc_empty(struct bom_context_memory memory)
     context->memory.resize(&context->memory, header_size + index_size + freelist_size + variables_size);
 
     struct bom_header *header = (struct bom_header *)context->memory.data;
-    strncpy(header->magic, "BOMStore", 8);
+    memcpy(header->magic, "BOMStore", 8);
     header->version = htonl(1);
     header->block_count = htonl(0);
     header->index_offset = htonl(header_size);

--- a/Libraries/libbom/Sources/bom_tree.c
+++ b/Libraries/libbom/Sources/bom_tree.c
@@ -82,7 +82,7 @@ bom_tree_alloc_empty(struct bom_context *context, const char *variable_name)
     uint32_t entry_index = bom_index_add(tree_context->context, entry, sizeof(*entry));
     free(entry);
 
-    strncpy(tree->magic, "tree", 4);
+    memcpy(tree->magic, "tree", 4);
     tree->version = htonl(1);
     tree->child = htonl(entry_index);
     tree->node_size = htonl(4096); // todo

--- a/Libraries/libcar/Sources/Reader.cpp
+++ b/Libraries/libcar/Sources/Reader.cpp
@@ -82,7 +82,11 @@ renditionIterate(std::function<void(Rendition const &)> const &iterator) const
         KeyValuePair kv = (KeyValuePair)it.second;
         car_rendition_key *rendition_key = (car_rendition_key *)kv.key;
         struct car_rendition_value *rendition_value = (struct car_rendition_value *)kv.value;
-        AttributeList attributes = AttributeList::Load(keyfmt->num_identifiers, keyfmt->identifier_list, rendition_key);
+        uint32_t *unpacked_identifiers = new uint32_t[sizeof(uint32_t)*keyfmt->num_identifiers];
+	for(size_t i = 0; i < keyfmt->num_identifiers; ++i) {
+		unpacked_identifiers[i] = keyfmt->identifier_list[i];
+	}
+	AttributeList attributes = AttributeList::Load(keyfmt->num_identifiers, unpacked_identifiers, rendition_key);
         Rendition rendition = Rendition::Load(attributes, rendition_value);
         iterator(rendition);
     }
@@ -264,7 +268,11 @@ lookupRenditions(Facet const &facet) const
         KeyValuePair value = (KeyValuePair)it->second;
         car_rendition_key *rendition_key = (car_rendition_key *)value.key;
         struct car_rendition_value *rendition_value = (struct car_rendition_value *)value.value;
-        AttributeList attributes = AttributeList::Load(keyfmt->num_identifiers, keyfmt->identifier_list, rendition_key);
+        uint32_t *unpacked_identifiers = new uint32_t[sizeof(uint32_t)*keyfmt->num_identifiers];
+	for(size_t i = 0; i < keyfmt->num_identifiers; ++i) {
+		unpacked_identifiers[i] = keyfmt->identifier_list[i];
+	}
+        AttributeList attributes = AttributeList::Load(keyfmt->num_identifiers, unpacked_identifiers, rendition_key);
         Rendition rendition = Rendition::Load(attributes, rendition_value);
         result.push_back(rendition);
     }

--- a/Libraries/libcar/Sources/Rendition.cpp
+++ b/Libraries/libcar/Sources/Rendition.cpp
@@ -528,7 +528,7 @@ write() const
     // Create header
     struct car_rendition_value header;
     memset(static_cast<void *>(&header), 0, sizeof(struct car_rendition_value));
-    strncpy(header.magic, "ISTC", 4);
+    memcpy(header.magic, "ISTC", 4);
     header.version = 1;
     // header.flags.is_header_flagged_fpo = 0;
     // header.flags.is_excluded_from_contrast_filter = 0;
@@ -675,7 +675,7 @@ write() const
     /* JPEG, RAW and non-standard formats adds one more header at the end */
     if (Rendition::Data::FormatSavedAsRawData(renditionData->format())) {
         struct car_rendition_data_header_raw raw_header;
-        strncpy(raw_header.magic, "DWAR", 4);
+        memcpy(raw_header.magic, "DWAR", 4);
         raw_header.length = compressed_data_length;
         memcpy(output_bytes, &raw_header, sizeof(struct car_rendition_data_header_raw));
         output_bytes += sizeof(struct car_rendition_data_header_raw);

--- a/Libraries/libcar/Sources/Writer.cpp
+++ b/Libraries/libcar/Sources/Writer.cpp
@@ -97,7 +97,7 @@ write() const
         return;
     }
 
-    strncpy(header->magic, "RATC", 4);
+    memcpy(header->magic, "RATC", 4);
     header->ui_version = 0x131; // TODO
     header->storage_version = 0xC; // TODO
     header->storage_timestamp = static_cast<uint32_t>(time(NULL)); // TODO
@@ -127,7 +127,7 @@ write() const
       std::vector<enum car_attribute_identifier> format = DetermineKeyFormat(_facets, _renditions);
       keyfmt_size = sizeof(struct car_key_format) + (format.size() * sizeof(uint32_t));
       keyfmt = (struct car_key_format *)malloc(keyfmt_size);
-      strncpy(keyfmt->magic, "tmfk", 4);
+      memcpy(keyfmt->magic, "tmfk", 4);
       keyfmt->reserved = 0;
       keyfmt->num_identifiers = format.size();
       for (size_t i = 0; i < format.size(); ++i) {
@@ -162,7 +162,11 @@ write() const
     bom_tree_reserve(renditions_tree_context, rendition_count);
     if (renditions_tree_context != NULL) {
         for (auto const &item : _renditions) {
-            auto attributes_value = item.second.attributes().write(keyfmt->num_identifiers, keyfmt->identifier_list);
+            uint32_t *unpacked_identifiers = new uint32_t[sizeof(uint32_t)*keyfmt->num_identifiers];
+	    for(size_t i = 0; i < keyfmt->num_identifiers; ++i) {
+		unpacked_identifiers[i] = keyfmt->identifier_list[i];
+            }
+            auto attributes_value = item.second.attributes().write(keyfmt->num_identifiers, unpacked_identifiers);
             auto rendition_value = item.second.write();
             bom_tree_add(
                 renditions_tree_context,


### PR DESCRIPTION
Fixed build errors related to passing address of packed `car_key_format` and replaced strncpy with memcpy to fix errors related to stringop-truncation.