### PR TITLE
address-of-packed-member & stringop truncation

### DIFF
--- a/Libraries/libbom/Sources/bom.c
+++ b/Libraries/libbom/Sources/bom.c
@@ -57,7 +57,7 @@ bom_alloc_empty(struct bom_context_memory memory)
     context->memory.resize(&context->memory, header_size + index_size + freelist_size + variables_size);
 
     struct bom_header *header = (struct bom_header *)context->memory.data;
-    strncpy(header->magic, "BOMStore", 8);
+    memcpy(header->magic, "BOMStore", 8);
     header->version = htonl(1);
     header->block_count = htonl(0);
     header->index_offset = htonl(header_size);

--- a/Libraries/libbom/Sources/bom_tree.c
+++ b/Libraries/libbom/Sources/bom_tree.c
@@ -82,7 +82,7 @@ bom_tree_alloc_empty(struct bom_context *context, const char *variable_name)
     uint32_t entry_index = bom_index_add(tree_context->context, entry, sizeof(*entry));
     free(entry);
 
-    strncpy(tree->magic, "tree", 4);
+    memcpy(tree->magic, "tree", 4);
     tree->version = htonl(1);
     tree->child = htonl(entry_index);
     tree->node_size = htonl(4096); // todo

--- a/Libraries/libcar/Sources/Reader.cpp
+++ b/Libraries/libcar/Sources/Reader.cpp
@@ -82,7 +82,9 @@ renditionIterate(std::function<void(Rendition const &)> const &iterator) const
         KeyValuePair kv = (KeyValuePair)it.second;
         car_rendition_key *rendition_key = (car_rendition_key *)kv.key;
         struct car_rendition_value *rendition_value = (struct car_rendition_value *)kv.value;
-        AttributeList attributes = AttributeList::Load(keyfmt->num_identifiers, keyfmt->identifier_list, rendition_key);
+        std::vector<uint32_t> unpacked_identifiers(keyfmt->num_identifiers, 0ul);
+        std::memcpy(unpacked_identifiers.data(), keyfmt->identifier_list, sizeof(uint32_t) * keyfmt->num_identifiers);
+        AttributeList attributes = AttributeList::Load(keyfmt->num_identifiers, unpacked_identifiers.data(), rendition_key);
         Rendition rendition = Rendition::Load(attributes, rendition_value);
         iterator(rendition);
     }
@@ -264,7 +266,9 @@ lookupRenditions(Facet const &facet) const
         KeyValuePair value = (KeyValuePair)it->second;
         car_rendition_key *rendition_key = (car_rendition_key *)value.key;
         struct car_rendition_value *rendition_value = (struct car_rendition_value *)value.value;
-        AttributeList attributes = AttributeList::Load(keyfmt->num_identifiers, keyfmt->identifier_list, rendition_key);
+        std::vector<uint32_t> unpacked_identifiers(keyfmt->num_identifiers, 0ul);
+        std::memcpy(unpacked_identifiers.data(), keyfmt->identifier_list, sizeof(uint32_t) * keyfmt->num_identifiers);
+        AttributeList attributes = AttributeList::Load(keyfmt->num_identifiers, unpacked_identifiers.data(), rendition_key);
         Rendition rendition = Rendition::Load(attributes, rendition_value);
         result.push_back(rendition);
     }

--- a/Libraries/libcar/Sources/Rendition.cpp
+++ b/Libraries/libcar/Sources/Rendition.cpp
@@ -477,7 +477,7 @@ Encode(Rendition const *rendition, ext::optional<Rendition::Data> data)
             err = deflate(&zlibStream, Z_FINISH);
             size_t block_size = sizeof(tmp) - zlibStream.avail_out;
             compressed_vector.resize(compressed_vector.size() + block_size);
-            memcpy(&compressed_vector[compressed_vector.size() - block_size], &tmp[0], block_size);
+            std::memcpy(&compressed_vector[compressed_vector.size() - block_size], &tmp[0], block_size);
             if (err == Z_STREAM_END) {  /* Done */
                 break;
             }
@@ -498,7 +498,7 @@ Encode(Rendition const *rendition, ext::optional<Rendition::Data> data)
     std::vector<uint8_t> output = std::vector<uint8_t>(sizeof(struct car_rendition_data_header1));
 
     struct car_rendition_data_header1 *header1 = reinterpret_cast<struct car_rendition_data_header1 *>(output.data());
-    memcpy(header1->magic, "MLEC", sizeof(header1->magic));
+    std::memcpy(header1->magic, "MLEC", sizeof(header1->magic));
     header1->length = compressed_vector.size();
     header1->compression = compression_magic;
     output.insert(output.end(), compressed_vector.begin(), compressed_vector.end());
@@ -528,7 +528,7 @@ write() const
     // Create header
     struct car_rendition_value header;
     memset(static_cast<void *>(&header), 0, sizeof(struct car_rendition_value));
-    strncpy(header.magic, "ISTC", 4);
+    std::memcpy(header.magic, "ISTC", 4);
     header.version = 1;
     // header.flags.is_header_flagged_fpo = 0;
     // header.flags.is_excluded_from_contrast_filter = 0;
@@ -653,35 +653,35 @@ write() const
     std::vector<uint8_t> output = std::vector<uint8_t>(rendition_header_size + extra_headers_size + compressed_data_length);
     uint8_t *output_bytes = reinterpret_cast<uint8_t *>(output.data());
 
-    memcpy(output_bytes, &header, sizeof(struct car_rendition_value));
+    std::memcpy(output_bytes, &header, sizeof(struct car_rendition_value));
     output_bytes += sizeof(struct car_rendition_value);
 
-    memcpy(output_bytes, info_slices, info_slices_size);
+    std::memcpy(output_bytes, info_slices, info_slices_size);
     output_bytes += info_slices_size;
     free(info_slices);
 
-    memcpy(output_bytes, &info_metrics, sizeof(struct car_rendition_info_metrics));
+    std::memcpy(output_bytes, &info_metrics, sizeof(struct car_rendition_info_metrics));
     output_bytes += sizeof(struct car_rendition_info_metrics);
 
-    memcpy(output_bytes, &info_composition, sizeof(struct car_rendition_info_composition));
+    std::memcpy(output_bytes, &info_composition, sizeof(struct car_rendition_info_composition));
     output_bytes += sizeof(struct car_rendition_info_composition);
 
-    memcpy(output_bytes, &info_bitmap_info, sizeof(struct car_rendition_info_bitmap_info));
+    std::memcpy(output_bytes, &info_bitmap_info, sizeof(struct car_rendition_info_bitmap_info));
     output_bytes += sizeof(struct car_rendition_info_bitmap_info);
 
-    memcpy(output_bytes, &info_bytes_per_row, sizeof(struct car_rendition_info_bytes_per_row));
+    std::memcpy(output_bytes, &info_bytes_per_row, sizeof(struct car_rendition_info_bytes_per_row));
     output_bytes += sizeof(struct car_rendition_info_bytes_per_row);
 
     /* JPEG, RAW and non-standard formats adds one more header at the end */
     if (Rendition::Data::FormatSavedAsRawData(renditionData->format())) {
         struct car_rendition_data_header_raw raw_header;
-        strncpy(raw_header.magic, "DWAR", 4);
+        std::memcpy(raw_header.magic, "DWAR", 4);
         raw_header.length = compressed_data_length;
-        memcpy(output_bytes, &raw_header, sizeof(struct car_rendition_data_header_raw));
+        std::memcpy(output_bytes, &raw_header, sizeof(struct car_rendition_data_header_raw));
         output_bytes += sizeof(struct car_rendition_data_header_raw);
     }
 
-    memcpy(output_bytes, compressed_data, compressed_data_length);
+    std::memcpy(output_bytes, compressed_data, compressed_data_length);
 
     return output;
 }

--- a/Libraries/libcar/Sources/Writer.cpp
+++ b/Libraries/libcar/Sources/Writer.cpp
@@ -162,7 +162,9 @@ write() const
     bom_tree_reserve(renditions_tree_context, rendition_count);
     if (renditions_tree_context != NULL) {
         for (auto const &item : _renditions) {
-            auto attributes_value = item.second.attributes().write(keyfmt->num_identifiers, keyfmt->identifier_list);
+            std::vector<uint32_t> unpacked_identifiers(keyfmt->num_identifiers, 0ul);
+            std::memcpy(unpacked_identifiers.data(), keyfmt->identifier_list, sizeof(uint32_t) * keyfmt->num_identifiers);
+            auto attributes_value = item.second.attributes().write(keyfmt->num_identifiers, unpacked_identifiers.data());
             auto rendition_value = item.second.write();
             bom_tree_add(
                 renditions_tree_context,

--- a/Libraries/libcar/Sources/Writer.cpp
+++ b/Libraries/libcar/Sources/Writer.cpp
@@ -97,7 +97,7 @@ write() const
         return;
     }
 
-    strncpy(header->magic, "RATC", 4);
+    std::memcpy(header->magic, "RATC", 4);
     header->ui_version = 0x131; // TODO
     header->storage_version = 0xC; // TODO
     header->storage_timestamp = static_cast<uint32_t>(time(NULL)); // TODO
@@ -127,7 +127,7 @@ write() const
       std::vector<enum car_attribute_identifier> format = DetermineKeyFormat(_facets, _renditions);
       keyfmt_size = sizeof(struct car_key_format) + (format.size() * sizeof(uint32_t));
       keyfmt = (struct car_key_format *)malloc(keyfmt_size);
-      strncpy(keyfmt->magic, "tmfk", 4);
+      std::memcpy(keyfmt->magic, "tmfk", 4);
       keyfmt->reserved = 0;
       keyfmt->num_identifiers = format.size();
       for (size_t i = 0; i < format.size(); ++i) {


### PR DESCRIPTION
Fixed build errors relating to taking the address of struct car_key_format member identifier_list by allocating and copying member to a vector.

Fixed build errors relating to strncpy() of string literals. memcpy() is the appropriate function in this instance as there is no intention that these be null terminated.