### PR TITLE
missing-prototypes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,8 +61,19 @@ endif ()
 # Enable all warnings.
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC" OR "${CMAKE_CXX_SIMULATE_ID}" STREQUAL "MSVC")
   add_compile_options(/D_CRT_SECURE_NO_WARNINGS) # TODO: /Wall /WX
-elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-  add_compile_options(-Wall -Werror)
+elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR
+        "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR
+        "${CMAKE_C_COMPILER_ID}" STREQUAL "Clang" OR
+        "${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
+  add_compile_options(-Wall -Werror -Wmissing-declarations
+      $<$<COMPILE_LANGUAGE:C>:-Wmissing-prototypes>
+      #Until we add explicit prototypes/declarations for definitions which 
+      #themselves provide a prototype, treating these warnings as errors will 
+      #break builds.
+      #Once prototypes and declarations are added please remove the following
+      # -Wno-error options.
+      -Wno-error=missing-declarations
+      $<$<COMPILE_LANGUAGE:C>:-Wno-error=missing-prototypes>)
   if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     add_compile_options(-Wno-multichar -Wno-sign-compare)
   endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,8 +66,6 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_CXX_COMPILER_ID}
   if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     add_compile_options(-Wno-multichar -Wno-sign-compare)
   endif ()
-elseif ("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_C_COMPILER_ID}" STREQUAL "Clang")
-  add_compile_options(-Wall -Werror -Wmissing-prototypes)
 else ()
   message(WARNING "Compiler not supported to enable warnings.")
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,8 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_CXX_COMPILER_ID}
   if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     add_compile_options(-Wno-multichar -Wno-sign-compare)
   endif ()
+elseif ("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_C_COMPILER_ID}" STREQUAL "Clang")
+  add_compile_options(-Wall -Werror -Wmissing-prototypes)
 else ()
   message(WARNING "Compiler not supported to enable warnings.")
 endif ()


### PR DESCRIPTION
Contributor @strager had recommended enabling missing-prototypes, which proved useful for identifying unused code. In addition to missing-prototypes in C code, this will enable -Wall and -Werror.